### PR TITLE
Fix: missing outputs for workflow_call on set-outputs workflow

### DIFF
--- a/.github/workflows/backend.set-outputs.yaml
+++ b/.github/workflows/backend.set-outputs.yaml
@@ -11,6 +11,16 @@ on:
         required: true
       HEROKU_APP_NAME_PROD_MAINNET:
         required: true
+    outputs:
+      environment:
+        description: "Deployment environment"
+        value: ${{ jobs.set-outputs.outputs.environment }}
+      version_number:
+        description: "App version"
+        value: ${{ jobs.set-outputs.outputs.version_number }}
+      resource_name:
+        description: "Resource name"
+        value: ${{ jobs.set-outputs.outputs.resource_name }}
 
 jobs:
   set-outputs:

--- a/.github/workflows/web.set-outputs.yaml
+++ b/.github/workflows/web.set-outputs.yaml
@@ -11,6 +11,16 @@ on:
         required: true
       HEROKU_APP_NAME_PROD_MAINNET:
         required: true
+    outputs:
+      environment:
+        description: "Deployment environment"
+        value: ${{ jobs.set-outputs.outputs.environment }}
+      version_number:
+        description: "App version"
+        value: ${{ jobs.set-outputs.outputs.version_number }}
+      resource_name:
+        description: "Resource name"
+        value: ${{ jobs.set-outputs.outputs.resource_name }}
 
 jobs:
   set-outputs:


### PR DESCRIPTION
### What

- Set outputs for workflow_call on set-outputs workflow

### Why

- Missing outputs for workflow_call on set-outputs workflow

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
