### PR TITLE
Refactor: set heroku_app_name as secret on workflows

### DIFF
--- a/.github/workflows/backend.deploy-heroku.yaml
+++ b/.github/workflows/backend.deploy-heroku.yaml
@@ -6,13 +6,12 @@ on:
       environment:
         type: string
         required: true
-      heroku_app_name:
-        type: string
-        required: true
       version:
         type: string
         required: true
     secrets:
+      HEROKU_APP_NAME:
+        required: true
       HEROKU_API_KEY:
         required: true
 
@@ -22,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: ${{ inputs.environment }}
-    env:
-      HEROKU_APP_NAME: ${{ inputs.heroku_app_name }}
     permissions:
       contents: "read"
 
@@ -43,6 +40,8 @@ jobs:
           path: /tmp
 
       - name: Load, tag and push Docker image
+        env:
+          HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
         run: |
           docker load --input /tmp/docker_image_backend.tar
           docker tag build-backend:${{ inputs.version }} registry.heroku.com/$HEROKU_APP_NAME/web
@@ -51,6 +50,7 @@ jobs:
 
       - name: Release Heroku App
         env:
+          HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
           curl -n -X POST https://api.heroku.com/apps/$HEROKU_APP_NAME/releases \

--- a/.github/workflows/backend.deploy.yaml
+++ b/.github/workflows/backend.deploy.yaml
@@ -19,9 +19,6 @@ jobs:
     uses: ./.github/workflows/backend.set-outputs.yaml
     with:
       run-type: ${{ inputs.run-type }}
-    secrets:
-      HEROKU_APP_NAME_STAGING_TESTNET: ${{ secrets.HEROKU_BACKEND_APP_NAME_STAGING_TESTNET }}
-      HEROKU_APP_NAME_PROD_MAINNET: ${{ secrets.HEROKU_BACKEND_APP_NAME_PROD_MAINNET }}
 
   build:
     name: Build backend
@@ -40,9 +37,9 @@ jobs:
     uses: ./.github/workflows/backend.deploy-heroku.yaml
     with:
       environment: ${{ needs.set-outputs.outputs.environment }}
-      heroku_app_name: ${{ needs.set-outputs.outputs.resource_name }}
       version: ${{ needs.set-outputs.outputs.version_number }}
     secrets:
+      HEROKU_APP_NAME: ${{ secrets.HEROKU_BACKEND_APP_NAME_STAGING_TESTNET }}
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
 
   deploy-prod-mainnet:
@@ -52,7 +49,7 @@ jobs:
     uses: ./.github/workflows/backend.deploy-heroku.yaml
     with:
       environment: ${{ needs.set-outputs.outputs.environment }}
-      heroku_app_name: ${{ needs.set-outputs.outputs.resource_name }}
       version: ${{ needs.set-outputs.outputs.version_number }}
     secrets:
+      HEROKU_APP_NAME: ${{ secrets.HEROKU_BACKEND_APP_NAME_PROD_MAINNET }}
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/backend.set-outputs.yaml
+++ b/.github/workflows/backend.set-outputs.yaml
@@ -6,11 +6,6 @@ on:
       run-type:
         type: string
         required: true
-    secrets:
-      HEROKU_APP_NAME_STAGING_TESTNET:
-        required: true
-      HEROKU_APP_NAME_PROD_MAINNET:
-        required: true
     outputs:
       environment:
         description: "Deployment environment"
@@ -18,9 +13,6 @@ on:
       version_number:
         description: "App version"
         value: ${{ jobs.set-outputs.outputs.version_number }}
-      resource_name:
-        description: "Resource name"
-        value: ${{ jobs.set-outputs.outputs.resource_name }}
 
 jobs:
   set-outputs:
@@ -30,7 +22,6 @@ jobs:
     outputs:
       environment: ${{ steps.set.outputs.environment }}
       version_number: ${{ steps.set.outputs.version_number }}
-      resource_name: ${{ steps.set.outputs.resource_name }}
 
     steps:
       - uses: actions/checkout@v4
@@ -48,15 +39,12 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [[ "${{ inputs.run-type }}" == "Deploy-to-Staging-Testnet" ]]; then
             echo "environment=Staging-Testnet" >> $GITHUB_OUTPUT
             echo "version_number=${{ steps.get-version.outputs.version }}" >> $GITHUB_OUTPUT
-            echo "resource_name=${{ secrets.HEROKU_APP_NAME_STAGING_TESTNET }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [[ "${{ inputs.run-type }}" == "Deploy-to-Prod-Mainnet" ]]; then
             echo "environment=Production-Mainnet" >> $GITHUB_OUTPUT
             echo "version_number=${{ steps.get-version.outputs.version }}" >> $GITHUB_OUTPUT
-            echo "resource_name=${{ secrets.HEROKU_APP_NAME_PROD_MAINNET }}" >> $GITHUB_OUTPUT
           else
             echo "environment=Disabled" >> $GITHUB_OUTPUT
             echo "version_number=Disabled" >> $GITHUB_OUTPUT
-            echo "resource_name=Disabled" >> $GITHUB_OUTPUT
           fi
 
       - name: Show Job details

--- a/.github/workflows/web.deploy-heroku.yaml
+++ b/.github/workflows/web.deploy-heroku.yaml
@@ -6,13 +6,12 @@ on:
       environment:
         type: string
         required: true
-      heroku_app_name:
-        type: string
-        required: true
       version:
         type: string
         required: true
     secrets:
+      HEROKU_APP_NAME:
+        required: true
       HEROKU_API_KEY:
         required: true
 
@@ -22,8 +21,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 15
     environment: ${{ inputs.environment }}
-    env:
-      HEROKU_APP_NAME: ${{ inputs.heroku_app_name }}
     permissions:
       contents: "read"
 
@@ -43,6 +40,8 @@ jobs:
           path: /tmp
 
       - name: Load, tag and push Docker image
+        env:
+          HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
         run: |
           docker load --input /tmp/docker_image_web.tar
           docker tag build-web:${{ inputs.version }} registry.heroku.com/$HEROKU_APP_NAME/web
@@ -51,6 +50,7 @@ jobs:
 
       - name: Release Heroku App
         env:
+          HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
           curl -n -X POST https://api.heroku.com/apps/$HEROKU_APP_NAME/releases \

--- a/.github/workflows/web.deploy.yaml
+++ b/.github/workflows/web.deploy.yaml
@@ -19,9 +19,6 @@ jobs:
     uses: ./.github/workflows/web.set-outputs.yaml
     with:
       run-type: ${{ inputs.run-type }}
-    secrets:
-      HEROKU_APP_NAME_STAGING_TESTNET: ${{ secrets.HEROKU_WEB_APP_NAME_STAGING_TESTNET }}
-      HEROKU_APP_NAME_PROD_MAINNET: ${{ secrets.HEROKU_WEB_APP_NAME_PROD_MAINNET }}
 
   build:
     name: Build web
@@ -43,6 +40,7 @@ jobs:
       heroku_app_name: ${{ needs.set-outputs.outputs.resource_name }}
       version: ${{ needs.set-outputs.outputs.version_number }}
     secrets:
+      HEROKU_APP_NAME: ${{ secrets.HEROKU_WEB_APP_NAME_STAGING_TESTNET }}
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
 
   deploy-prod-mainnet:
@@ -55,4 +53,5 @@ jobs:
       heroku_app_name: ${{ needs.set-outputs.outputs.resource_name }}
       version: ${{ needs.set-outputs.outputs.version_number }}
     secrets:
+      HEROKU_APP_NAME: ${{ secrets.HEROKU_WEB_APP_NAME_PROD_MAINNET }}
       HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}

--- a/.github/workflows/web.set-outputs.yaml
+++ b/.github/workflows/web.set-outputs.yaml
@@ -6,11 +6,6 @@ on:
       run-type:
         type: string
         required: true
-    secrets:
-      HEROKU_APP_NAME_STAGING_TESTNET:
-        required: true
-      HEROKU_APP_NAME_PROD_MAINNET:
-        required: true
     outputs:
       environment:
         description: "Deployment environment"
@@ -18,9 +13,6 @@ on:
       version_number:
         description: "App version"
         value: ${{ jobs.set-outputs.outputs.version_number }}
-      resource_name:
-        description: "Resource name"
-        value: ${{ jobs.set-outputs.outputs.resource_name }}
 
 jobs:
   set-outputs:
@@ -30,7 +22,6 @@ jobs:
     outputs:
       environment: ${{ steps.set.outputs.environment }}
       version_number: ${{ steps.set.outputs.version_number }}
-      resource_name: ${{ steps.set.outputs.resource_name }}
 
     steps:
       - uses: actions/checkout@v4
@@ -48,15 +39,12 @@ jobs:
           if [ "${{ github.event_name }}" == "workflow_dispatch" ] && [[ "${{ inputs.run-type }}" == "Deploy-to-Staging-Testnet" ]]; then
             echo "environment=Staging-Testnet" >> $GITHUB_OUTPUT
             echo "version_number=${{ steps.get-version.outputs.version }}" >> $GITHUB_OUTPUT
-            echo "resource_name=${{ secrets.HEROKU_APP_NAME_STAGING_TESTNET }}" >> $GITHUB_OUTPUT
           elif [ "${{ github.event_name }}" == "workflow_dispatch" ] && [[ "${{ inputs.run-type }}" == "Deploy-to-Prod-Mainnet" ]]; then
             echo "environment=Production-Mainnet" >> $GITHUB_OUTPUT
             echo "version_number=${{ steps.get-version.outputs.version }}" >> $GITHUB_OUTPUT
-            echo "resource_name=${{ secrets.HEROKU_APP_NAME_PROD_MAINNET }}" >> $GITHUB_OUTPUT
           else
             echo "environment=Disabled" >> $GITHUB_OUTPUT
             echo "version_number=Disabled" >> $GITHUB_OUTPUT
-            echo "resource_name=Disabled" >> $GITHUB_OUTPUT
           fi
 
       - name: Show Job details


### PR DESCRIPTION
### What

- Set heroku_app_name as secret on workflows

### Why

- Necessary due to the workflow architecture built for this project, the set-outputs is not able to expose the resource name as a secret

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
