### PR TITLE
Fix: wrong heroku release params

### DIFF
--- a/.github/workflows/backend.deploy-heroku.yaml
+++ b/.github/workflows/backend.deploy-heroku.yaml
@@ -57,4 +57,5 @@ jobs:
             -H "Content-Type: application/json" \
             -H "Accept: application/vnd.heroku+json; version=3.docker-releases" \
             -H "Authorization: Bearer $HEROKU_API_KEY" \
-            -d '{"updates":[{"type":"web","docker_image":"registry.heroku.com/'"$HEROKU_APP_NAME"'/web"}]}'
+            -d "$(jq -n --arg image "registry.heroku.com/$HEROKU_APP_NAME/web" \
+              '{updates: [{type: "web", docker_image: $image}]}')"

--- a/.github/workflows/backend.deploy.yaml
+++ b/.github/workflows/backend.deploy.yaml
@@ -33,7 +33,7 @@ jobs:
   deploy-staging-testnet:
     name: Deploy to Heroku (Staging Testnet)
     needs: [set-outputs, build, code-quality]
-    if: needs.code-quality.result == 'success' && needs.build.result == 'success' && needs.set-outputs.result == 'success' && needs.set-outputs.outputs.environment != 'Disabled'
+    if: needs.code-quality.result == 'success' && needs.build.result == 'success' && needs.set-outputs.result == 'success' && needs.set-outputs.outputs.environment == 'Staging-Testnet'
     uses: ./.github/workflows/backend.deploy-heroku.yaml
     with:
       environment: ${{ needs.set-outputs.outputs.environment }}
@@ -45,7 +45,7 @@ jobs:
   deploy-prod-mainnet:
     name: Deploy to Heroku (Production Mainnet)
     needs: [set-outputs, deploy-staging-testnet]
-    if: needs.deploy-staging-testnet.result == 'success' && needs.set-outputs.result == 'success' && needs.set-outputs.outputs.environment != 'Disabled'
+    if: needs.deploy-staging-testnet.result == 'success' && needs.set-outputs.result == 'success' && needs.set-outputs.outputs.environment == 'Production-Mainnet'
     uses: ./.github/workflows/backend.deploy-heroku.yaml
     with:
       environment: ${{ needs.set-outputs.outputs.environment }}

--- a/.github/workflows/web.deploy-heroku.yaml
+++ b/.github/workflows/web.deploy-heroku.yaml
@@ -57,4 +57,5 @@ jobs:
             -H "Content-Type: application/json" \
             -H "Accept: application/vnd.heroku+json; version=3.docker-releases" \
             -H "Authorization: Bearer $HEROKU_API_KEY" \
-            -d '{"updates":[{"type":"web","docker_image":"registry.heroku.com/'"$HEROKU_APP_NAME"'/web"}]}'
+            -d "$(jq -n --arg image "registry.heroku.com/$HEROKU_APP_NAME/web" \
+              '{updates: [{type: "web", docker_image: $image}]}')"

--- a/.github/workflows/web.deploy.yaml
+++ b/.github/workflows/web.deploy.yaml
@@ -33,7 +33,7 @@ jobs:
   deploy-staging-testnet:
     name: Deploy to Heroku (Staging Testnet)
     needs: [set-outputs, build, code-quality]
-    if: needs.code-quality.result == 'success' && needs.build.result == 'success' && needs.set-outputs.result == 'success' && needs.set-outputs.outputs.environment != 'Disabled'
+    if: needs.code-quality.result == 'success' && needs.build.result == 'success' && needs.set-outputs.result == 'success' && needs.set-outputs.outputs.environment == 'Staging-Testnet'
     uses: ./.github/workflows/web.deploy-heroku.yaml
     with:
       environment: ${{ needs.set-outputs.outputs.environment }}
@@ -46,7 +46,7 @@ jobs:
   deploy-prod-mainnet:
     name: Deploy to Heroku (Production Mainnet)
     needs: [set-outputs, deploy-staging-testnet]
-    if: needs.deploy-staging-testnet.result == 'success' && needs.set-outputs.result == 'success' && needs.set-outputs.outputs.environment != 'Disabled'
+    if: needs.deploy-staging-testnet.result == 'success' && needs.set-outputs.result == 'success' && needs.set-outputs.outputs.environment == 'Production-Mainnet'
     uses: ./.github/workflows/web.deploy-heroku.yaml
     with:
       environment: ${{ needs.set-outputs.outputs.environment }}


### PR DESCRIPTION
### What

- Put fixed heroku release params

### Why

- Wrong heroku release params (POST command on workflow)

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
