### PR TITLE
Fix: wrong params to deploy to heroku

### DIFF
--- a/.github/workflows/backend.deploy-heroku.yaml
+++ b/.github/workflows/backend.deploy-heroku.yaml
@@ -53,9 +53,9 @@ jobs:
           HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
-          curl -n -X POST https://api.heroku.com/apps/$HEROKU_APP_NAME/releases \
+          curl -n -X PATCH https://api.heroku.com/apps/$HEROKU_APP_NAME/formation \
             -H "Content-Type: application/json" \
             -H "Accept: application/vnd.heroku+json; version=3.docker-releases" \
             -H "Authorization: Bearer $HEROKU_API_KEY" \
             -d "$(jq -n --arg image "registry.heroku.com/$HEROKU_APP_NAME/web" \
-              '{updates: [{type: "web", docker_image: $image}]}')"
+                  '{updates: [{type: "web", docker_image: $image}]}')"

--- a/.github/workflows/web.deploy-heroku.yaml
+++ b/.github/workflows/web.deploy-heroku.yaml
@@ -53,9 +53,10 @@ jobs:
           HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
           HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
         run: |
-          curl -n -X POST https://api.heroku.com/apps/$HEROKU_APP_NAME/releases \
+          curl -n -X PATCH https://api.heroku.com/apps/$HEROKU_APP_NAME/formation \
             -H "Content-Type: application/json" \
             -H "Accept: application/vnd.heroku+json; version=3.docker-releases" \
             -H "Authorization: Bearer $HEROKU_API_KEY" \
             -d "$(jq -n --arg image "registry.heroku.com/$HEROKU_APP_NAME/web" \
-              '{updates: [{type: "web", docker_image: $image}]}')"
+                  '{updates: [{type: "web", docker_image: $image}]}')"
+

--- a/.github/workflows/web.deploy.yaml
+++ b/.github/workflows/web.deploy.yaml
@@ -37,7 +37,6 @@ jobs:
     uses: ./.github/workflows/web.deploy-heroku.yaml
     with:
       environment: ${{ needs.set-outputs.outputs.environment }}
-      heroku_app_name: ${{ needs.set-outputs.outputs.resource_name }}
       version: ${{ needs.set-outputs.outputs.version_number }}
     secrets:
       HEROKU_APP_NAME: ${{ secrets.HEROKU_WEB_APP_NAME_STAGING_TESTNET }}
@@ -50,7 +49,6 @@ jobs:
     uses: ./.github/workflows/web.deploy-heroku.yaml
     with:
       environment: ${{ needs.set-outputs.outputs.environment }}
-      heroku_app_name: ${{ needs.set-outputs.outputs.resource_name }}
       version: ${{ needs.set-outputs.outputs.version_number }}
     secrets:
       HEROKU_APP_NAME: ${{ secrets.HEROKU_WEB_APP_NAME_PROD_MAINNET }}


### PR DESCRIPTION
### What

- Stop passing unnecessary/wrong params to deploy-heroku workflows

### Why

- Causing errors during the action's runtime

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
