### PR TITLE
Refactor: use heroku cli to release builds on CI

### DIFF
--- a/.github/workflows/backend.deploy-heroku.yaml
+++ b/.github/workflows/backend.deploy-heroku.yaml
@@ -60,18 +60,13 @@ jobs:
             password $HEROKU_API_KEY" > ~/.netrc
           chmod 600 ~/.netrc
 
-      - name: Release Heroku App
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
+
+      - name: Release Heroku App via CLI
         env:
           HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
-          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-        run: |
-          curl -n -X PATCH https://api.heroku.com/apps/$HEROKU_APP_NAME/formation \
-            -H "Content-Type: application/json" \
-            -H "Accept: application/vnd.heroku+json; version=3.docker-releases" \
-            -H "Authorization: Bearer $HEROKU_API_KEY" \
-            -d "$(jq -n --arg image "registry.heroku.com/$HEROKU_APP_NAME/web" \
-                  '{updates: [{type: "web", docker_image: $image}]}')"
+        run: heroku container:release web --app $HEROKU_APP_NAME
 
       - name: Cleanup .netrc
-        run: |
-          rm -f ~/.netrc
+        run: rm -f ~/.netrc

--- a/.github/workflows/web.deploy-heroku.yaml
+++ b/.github/workflows/web.deploy-heroku.yaml
@@ -60,19 +60,14 @@ jobs:
             password $HEROKU_API_KEY" > ~/.netrc
           chmod 600 ~/.netrc
 
-      - name: Release Heroku App
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
+
+      - name: Release Heroku App via CLI
         env:
           HEROKU_APP_NAME: ${{ secrets.HEROKU_APP_NAME }}
-          HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
-        run: |
-          curl -n -X PATCH https://api.heroku.com/apps/$HEROKU_APP_NAME/formation \
-            -H "Content-Type: application/json" \
-            -H "Accept: application/vnd.heroku+json; version=3.docker-releases" \
-            -H "Authorization: Bearer $HEROKU_API_KEY" \
-            -d "$(jq -n --arg image "registry.heroku.com/$HEROKU_APP_NAME/web" \
-                  '{updates: [{type: "web", docker_image: $image}]}')"
+        run: heroku container:release web --app $HEROKU_APP_NAME
 
       - name: Cleanup .netrc
-        run: |
-          rm -f ~/.netrc
+        run: rm -f ~/.netrc
 


### PR DESCRIPTION
### What

- Use heroku cli to release builds on CI

### Why

- Keep the CI accurate with the Heroku CLI changes, instead of directly calling the API

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
