### PR TITLE
Fix: wrong params to set outputs workflow

### DIFF
--- a/.github/workflows/backend.yaml
+++ b/.github/workflows/backend.yaml
@@ -24,9 +24,6 @@ jobs:
     uses: ./.github/workflows/backend.set-outputs.yaml
     with:
       run-type: ${{ inputs.run-type }}
-    secrets:
-      HEROKU_APP_NAME_STAGING_TESTNET: ${{ secrets.HEROKU_BACKEND_APP_NAME_STAGING_TESTNET }}
-      HEROKU_APP_NAME_PROD_MAINNET: ${{ secrets.HEROKU_BACKEND_APP_NAME_PROD_MAINNET }}
 
   build:
     name: Build backend

--- a/.github/workflows/web.yaml
+++ b/.github/workflows/web.yaml
@@ -25,9 +25,6 @@ jobs:
     uses: ./.github/workflows/web.set-outputs.yaml
     with:
       run-type: ${{ inputs.run-type }}
-    secrets:
-      HEROKU_APP_NAME_STAGING_TESTNET: ${{ secrets.HEROKU_WEB_APP_NAME_STAGING_TESTNET }}
-      HEROKU_APP_NAME_PROD_MAINNET: ${{ secrets.HEROKU_WEB_APP_NAME_PROD_MAINNET }}
 
   build:
     name: Build web


### PR DESCRIPTION
### What

- Remove unnecessary params set when using set-outputs workflows

### Why

- Wrong params to set-outputs workflows throwing errors on CI

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
