### PR TITLE
Fix: Extend instance TTL and check ended in recover

### DIFF
--- a/contracts/airdrop/src/lib.rs
+++ b/contracts/airdrop/src/lib.rs
@@ -11,6 +11,11 @@ use soroban_sdk::{
 use stellar_crypto::sha256::Sha256;
 use stellar_merkle_distributor::{IndexableLeaf, MerkleDistributor};
 
+pub const DAY_IN_LEDGERS: u32 = 17280;
+
+pub const INSTANCE_EXTEND_AMOUNT: u32 = 7 * DAY_IN_LEDGERS;
+pub const INSTANCE_TTL_THRESHOLD: u32 = INSTANCE_EXTEND_AMOUNT - DAY_IN_LEDGERS;
+
 type Distributor = MerkleDistributor<Sha256>;
 
 #[contracttype]
@@ -115,6 +120,10 @@ impl AirdropContract {
 
         let token_client = Self::token_client(e);
         token_client.transfer(&e.current_contract_address(), &receiver, &amount);
+
+        e.storage()
+            .instance()
+            .extend_ttl(INSTANCE_TTL_THRESHOLD, INSTANCE_EXTEND_AMOUNT);
     }
 
     /// Recovers any unclaimed tokens from the contract back to the funder and disables further claims.
@@ -122,6 +131,10 @@ impl AirdropContract {
     /// # Arguments:
     /// * `e` - The Soroban environment.
     pub fn recover_unclaimed(e: &Env) {
+        if Self::is_ended(e) {
+            panic_with_error!(e, AirdropError::Ended);
+        }
+
         let funder = e
             .storage()
             .instance()

--- a/contracts/airdrop/src/test.rs
+++ b/contracts/airdrop/src/test.rs
@@ -290,6 +290,29 @@ fn test_recover_unclaimed_to_funder() {
 }
 
 #[test]
+#[should_panic(expected = "Error(Contract, #1000)")]
+fn test_recover_unclaimed_after_ended() {
+    let e = Env::default();
+    e.mock_all_auths_allowing_non_root_auth();
+
+    let owner = Address::generate(&e);
+    let token_client = create_token_contract(&e, &owner);
+
+    let args = make_args(
+        &e,
+        hex!("11932105f1a4d0092e87cead3a543da5afd8adcff63f9a8ceb6c5db3c8135722"),
+        token_client.address.clone(),
+        1000,
+        owner.clone(),
+    );
+    let contract_id = e.register(AirdropContract, args);
+    let client = AirdropContractClient::new(&e, &contract_id);
+
+    client.recover_unclaimed();
+    client.recover_unclaimed();
+}
+
+#[test]
 fn test_recover_unclaimed_no_funder_auth() {
     let e = Env::default();
     e.mock_all_auths_allowing_non_root_auth();


### PR DESCRIPTION
### What

This extends the instance TTL every time the `claim` function is called and adds a check for `Ended` when `recover_unclaimed` is called.

### Why

Prevent instance and code from being archived and make the error nicer when `recover_unclaimed` is called multiple times.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
