### PR TITLE
Fix(web): search param usage breaking invite page

### DIFF
--- a/apps/web/src/app/auth/pages/invite/index.tsx
+++ b/apps/web/src/app/auth/pages/invite/index.tsx
@@ -1,5 +1,5 @@
 import { useSuspenseQuery } from '@tanstack/react-query'
-import { useNavigate, useSearch } from '@tanstack/react-router'
+import { useNavigate } from '@tanstack/react-router'
 import { useMemo } from 'react'
 
 import { WalletPagesPath } from 'src/app/wallet/routes/types'
@@ -8,10 +8,11 @@ import { InviteTemplate } from './template'
 import { useCreateWallet } from '../../queries/use-create-wallet'
 import { getInvitationInfoOptions } from '../../queries/use-get-invitation-info'
 import { useLogIn } from '../../queries/use-login'
+import { inviteRoute } from '../../routes'
 import { AuthPagesPath } from '../../routes/types'
 
 export const Invite = () => {
-  const search = useSearch({ from: AuthPagesPath.INVITE })
+  const search = inviteRoute.useSearch()
   const navigate = useNavigate()
 
   const createWallet = useCreateWallet({

--- a/apps/web/src/app/auth/routes/components/auth-route-loading/index.tsx
+++ b/apps/web/src/app/auth/routes/components/auth-route-loading/index.tsx
@@ -1,0 +1,13 @@
+import { OnboardingBackgroundImage } from 'src/app/core/components'
+import { Loading } from 'src/components/atoms'
+
+export const AuthRouteLoading = () => {
+  return (
+    <div>
+      <OnboardingBackgroundImage />
+      <div className="flex justify-center items-center h-screen">
+        <Loading />
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/auth/routes/index.tsx
+++ b/apps/web/src/app/auth/routes/index.tsx
@@ -6,6 +6,7 @@ import { publicRootRoute } from 'src/app/core/router/routeTree'
 import { Welcome, Invite, InviteResend, Recover, RecoverConfirm, LogIn } from '../pages'
 import { AuthPagesPath } from './types'
 import { getInvitationInfoOptions } from '../queries/use-get-invitation-info'
+import { AuthRouteLoading } from './components/auth-route-loading'
 
 const welcomeRoute = createRoute({
   getParentRoute: () => publicRootRoute,
@@ -13,10 +14,11 @@ const welcomeRoute = createRoute({
   component: Welcome,
 })
 
-const inviteRoute = createRoute({
+export const inviteRoute = createRoute({
   getParentRoute: () => publicRootRoute,
   path: AuthPagesPath.INVITE,
   component: Invite,
+  pendingComponent: AuthRouteLoading,
   validateSearch: search =>
     yup
       .object({


### PR DESCRIPTION
### What

- Fixes: search param usage breaking invite page
   - `useSearch` loses reference to the inviteRoute

### Why

- Uses `useSearch` directly from the `inviteRoute` instance

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
