### PR TITLE
Register wallet within wallet-backend service

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,1 +1,0 @@
-make format-code && make lint-fix APP=web && make lint-fix APP=backend && make type-check APP=web && make type-check APP=backend

--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -58,6 +58,7 @@
     "dotenv-safe": "^9.1.0",
     "express": "^4.21.1",
     "express-async-errors": "^3.1.1",
+    "jose": "^6.0.12",
     "jsonwebtoken": "^9.0.2",
     "minimatch": "^3.1.2",
     "pg": "^8.16.3",

--- a/apps/backend/src/api/embedded-wallets/use-cases/create-wallet/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/create-wallet/index.ts
@@ -14,7 +14,6 @@ import { UnauthorizedException } from 'errors/exceptions/unauthorized'
 import { generateToken } from 'interfaces/jwt'
 import SDPEmbeddedWallets from 'interfaces/sdp-embedded-wallets'
 import { SDPEmbeddedWalletsType, WalletStatus } from 'interfaces/sdp-embedded-wallets/types'
-import WalletBackend from 'interfaces/wallet-backend'
 import { WebAuthnChallengeService } from 'interfaces/webauthn-challenge'
 import { IWebauthnChallengeService } from 'interfaces/webauthn-challenge/types'
 
@@ -27,21 +26,18 @@ export class CreateWallet extends UseCaseBase implements IUseCaseHttp<ResponseSc
   private passkeyRepository: PasskeyRepositoryType
   private webauthnChallengeService: IWebauthnChallengeService
   private sdpEmbeddedWallets: SDPEmbeddedWalletsType
-  private walletBackend: WalletBackend
 
   constructor(
     userRepository?: UserRepositoryType,
     passkeyRepository?: PasskeyRepositoryType,
     webauthnChallengeService?: IWebauthnChallengeService,
-    sdpEmbeddedWallets?: SDPEmbeddedWalletsType,
-    walletBackend?: WalletBackend
+    sdpEmbeddedWallets?: SDPEmbeddedWalletsType
   ) {
     super()
     this.userRepository = userRepository || UserRepository.getInstance()
     this.passkeyRepository = passkeyRepository || PasskeyRepository.getInstance()
     this.webauthnChallengeService = webauthnChallengeService || WebAuthnChallengeService.getInstance()
     this.sdpEmbeddedWallets = sdpEmbeddedWallets || SDPEmbeddedWallets.getInstance()
-    this.walletBackend = walletBackend || WalletBackend.getInstance()
   }
 
   parseResponseMessage(status: WalletStatus): string {

--- a/apps/backend/src/api/embedded-wallets/use-cases/create-wallet/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/create-wallet/index.ts
@@ -14,6 +14,7 @@ import { UnauthorizedException } from 'errors/exceptions/unauthorized'
 import { generateToken } from 'interfaces/jwt'
 import SDPEmbeddedWallets from 'interfaces/sdp-embedded-wallets'
 import { SDPEmbeddedWalletsType, WalletStatus } from 'interfaces/sdp-embedded-wallets/types'
+import WalletBackend from 'interfaces/wallet-backend'
 import { WebAuthnChallengeService } from 'interfaces/webauthn-challenge'
 import { IWebauthnChallengeService } from 'interfaces/webauthn-challenge/types'
 
@@ -26,18 +27,21 @@ export class CreateWallet extends UseCaseBase implements IUseCaseHttp<ResponseSc
   private passkeyRepository: PasskeyRepositoryType
   private webauthnChallengeService: IWebauthnChallengeService
   private sdpEmbeddedWallets: SDPEmbeddedWalletsType
+  private walletBackend: WalletBackend
 
   constructor(
     userRepository?: UserRepositoryType,
     passkeyRepository?: PasskeyRepositoryType,
     webauthnChallengeService?: IWebauthnChallengeService,
-    sdpEmbeddedWallets?: SDPEmbeddedWalletsType
+    sdpEmbeddedWallets?: SDPEmbeddedWalletsType,
+    walletBackend?: WalletBackend
   ) {
     super()
     this.userRepository = userRepository || UserRepository.getInstance()
     this.passkeyRepository = passkeyRepository || PasskeyRepository.getInstance()
     this.webauthnChallengeService = webauthnChallengeService || WebAuthnChallengeService.getInstance()
     this.sdpEmbeddedWallets = sdpEmbeddedWallets || SDPEmbeddedWallets.getInstance()
+    this.walletBackend = walletBackend || WalletBackend.getInstance()
   }
 
   parseResponseMessage(status: WalletStatus): string {

--- a/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.test.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.test.ts
@@ -72,14 +72,19 @@ describe('GetWallet', () => {
       status: WalletStatus.SUCCESS,
       contract_address: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE',
     } as CheckWalletStatusResponse)
-    mockedUserRepository.updateUser.mockResolvedValue({ ...user, contractAddress: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE' } as User)
+    mockedUserRepository.updateUser.mockResolvedValue({
+      ...user,
+      contractAddress: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE',
+    } as User)
 
     const payload = { id: 'user-123' }
     const result = await getWallet.handle(payload)
     expect(result.data.status).toBe(WalletStatus.SUCCESS)
     expect(result.data.address).toBe('CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE')
     expect(mockedSDPEmbeddedWallets.checkWalletStatus).toHaveBeenCalledTimes(2)
-    expect(mockedUserRepository.updateUser).toHaveBeenCalledWith('user-123', { contractAddress: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE' })
+    expect(mockedUserRepository.updateUser).toHaveBeenCalledWith('user-123', {
+      contractAddress: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE',
+    })
   })
 
   it('should return pending status if wallet is not created after retries', async () => {

--- a/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.test.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.test.ts
@@ -70,16 +70,16 @@ describe('GetWallet', () => {
     } as CheckWalletStatusResponse)
     mockedSDPEmbeddedWallets.checkWalletStatus.mockResolvedValueOnce({
       status: WalletStatus.SUCCESS,
-      contract_address: 'new-wallet-address',
+      contract_address: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE',
     } as CheckWalletStatusResponse)
-    mockedUserRepository.updateUser.mockResolvedValue({ ...user, contractAddress: 'new-wallet-address' } as User)
+    mockedUserRepository.updateUser.mockResolvedValue({ ...user, contractAddress: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE' } as User)
 
     const payload = { id: 'user-123' }
     const result = await getWallet.handle(payload)
     expect(result.data.status).toBe(WalletStatus.SUCCESS)
-    expect(result.data.address).toBe('new-wallet-address')
+    expect(result.data.address).toBe('CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE')
     expect(mockedSDPEmbeddedWallets.checkWalletStatus).toHaveBeenCalledTimes(2)
-    expect(mockedUserRepository.updateUser).toHaveBeenCalledWith('user-123', { contractAddress: 'new-wallet-address' })
+    expect(mockedUserRepository.updateUser).toHaveBeenCalledWith('user-123', { contractAddress: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE' })
   })
 
   it('should return pending status if wallet is not created after retries', async () => {

--- a/apps/backend/src/config/.env.example
+++ b/apps/backend/src/config/.env.example
@@ -1,5 +1,6 @@
 # APPLICATION
 FRONT_ADDRESS="http://localhost:3000"
+SERVER_ADDRESS="http://localhost:8000"
 DEPLOY_STAGE="local"
 ENVIRONMENT_NAME="staging"
 NODE_ENV="development"
@@ -17,14 +18,18 @@ DATABASE_PASSWORD=postgres
 # INTEGRATIONS
 SDP_EMBEDDED_WALLETS_URL="https://stellar-disbursement-platform-backend-dev.stellar.org/embedded-wallets"
 SDP_EMBEDDED_WALLETS_API_KEY="your-sdp-embedded-wallets-api-key"
+
 STELLAR_HORIZON_URL="https://horizon-testnet.stellar.org"
 STELLAR_SOROBAN_RPC_URL="https://soroban-testnet.stellar.org"
+
+STELLAR_WALLET_BACKEND_URL="https://wallet-backend-testnet-21ac687b8418.herokuapp.com"
+JWT_SECRET_KEY_WALLET_BACKEND="***" # Generate on: https://lab.stellar.org/account/create?$=network$id=testnet&label=Testnet&horizonUrl=https:////horizon-testnet.stellar.org&rpcUrl=https:////soroban-testnet.stellar.org&passphrase=Test%20SDF%20Network%20/;%20September%202015;;
 
 STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
 STELLAR_MAX_FEE="10000"
 
-STELLAR_SOURCE_ACCOUNT_PRIVATE_KEY="SAARF2ZWAHZJMKA6LXIFVNIHUBEUTMKV5NWCCUZV6ORPKLUK6RSOYZ4D"
-STELLAR_SOURCE_ACCOUNT_PUBLIC_KEY="GAX7FKBADU7HQFB3EYLCYPFKIXHE7SJSBCX7CCGXVVWJ5OU3VTWOFEI5"
+STELLAR_SOURCE_ACCOUNT_PRIVATE_KEY="***"
+STELLAR_SOURCE_ACCOUNT_PUBLIC_KEY="***"
 
 STELLAR_TOKEN_CONTRACT_NATIVE="CDLZFC3SYJYDZT7K67VZ75HPJVIEUVNIXF47ZG2FB2RMQQVU2HHGCYSC"
 STELLAR_TOKEN_CONTRACT_USDC="CDTY3P6OVY3SMZXR3DZA667NAXFECA6A3AOZXEU33DD2ACBY43CIKDPT"

--- a/apps/backend/src/interfaces/wallet-backend/auth/jwt.ts
+++ b/apps/backend/src/interfaces/wallet-backend/auth/jwt.ts
@@ -1,0 +1,57 @@
+import crypto from 'crypto'
+
+import { Keypair, StrKey } from '@stellar/stellar-sdk'
+import { SignJWT } from 'jose'
+
+import { getValueFromEnv } from 'config/env-utils'
+
+import { TokenPayload } from './types'
+
+const SECRET_KEY = getValueFromEnv('JWT_SECRET_KEY_WALLET_BACKEND')
+const PUBLIC_KEY = Keypair.fromSecret(SECRET_KEY).publicKey() // Public key used as subject in JWT
+const AUDIENCE = getValueFromEnv(
+  'STELLAR_WALLET_BACKEND_URL',
+  'https://wallet-backend-testnet-21ac687b8418.herokuapp.com'
+)
+  .replace('https://', '')
+  .replace('http://', '') // Remove protocol from URL to match wallet-backend requirements
+
+/**
+ * Generate a JWT token as per wallet-backend requirements: https://github.com/stellar/wallet-backend?tab=readme-ov-file#authentication
+ *
+ * @param {TokenPayload} payload - The payload to include in the JWT.
+ * @returns {string} - The generated JWT token.
+ */
+export async function generateToken(payload: TokenPayload): Promise<string> {
+  payload.bodyHash = hashBody(payload.bodyHash)
+
+  // Decode StrKey to raw bytes
+  const rawSecretKey = StrKey.decodeEd25519SecretSeed(SECRET_KEY) // Uint8Array(32)
+  const privateKey = Buffer.from(rawSecretKey)
+
+  const now = Math.floor(Date.now() / 1000)
+
+  const claims = {
+    ...payload,
+    iat: now, // Issued at time
+    exp: now + 5, // Set expiration time to 5 seconds from now
+    sub: PUBLIC_KEY, // Use public key as subject
+    aud: [AUDIENCE], // Audience is the wallet backend URL
+  }
+
+  // Construct the key in format JWK
+  const jwk = {
+    kty: 'OKP',
+    crv: 'Ed25519',
+    d: privateKey.toString('base64url'),
+    x: Buffer.from(Keypair.fromSecret(SECRET_KEY).rawPublicKey()).toString('base64url'),
+  }
+
+  const token = await new SignJWT(claims).setProtectedHeader({ alg: 'EdDSA' }).sign(jwk)
+
+  return token
+}
+
+export function hashBody(body: string): string {
+  return crypto.createHash('sha256').update(Buffer.from(body)).digest('hex')
+}

--- a/apps/backend/src/interfaces/wallet-backend/auth/types.ts
+++ b/apps/backend/src/interfaces/wallet-backend/auth/types.ts
@@ -1,0 +1,4 @@
+export type TokenPayload = {
+  methodAndPath: string
+  bodyHash: string
+}

--- a/apps/backend/src/interfaces/wallet-backend/index.test.ts
+++ b/apps/backend/src/interfaces/wallet-backend/index.test.ts
@@ -1,0 +1,124 @@
+import axios from 'axios'
+
+import { getValueFromEnv } from 'config/env-utils'
+
+import WalletBackend, { CONNECTION_TIMEOUT } from '.'
+
+describe('WalletBackend', () => {
+  const connection = axios.create({
+    baseURL: getValueFromEnv('STELLAR_WALLET_BACKEND_URL', 'https://wallet-backend-testnet-21ac687b8418.herokuapp.com'),
+    timeout: CONNECTION_TIMEOUT,
+  })
+  const walletBackend = new WalletBackend(connection)
+
+  afterEach(() => {
+    vi.clearAllMocks()
+    vi.restoreAllMocks()
+  })
+
+  describe('registerAccount', () => {
+    test('should register an account within wallet backend service', async () => {
+      vi.spyOn(connection, 'post').mockResolvedValue({
+        data: {},
+        status: 200,
+      })
+
+      const response = await walletBackend.registerAccount({
+        address: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE',
+      })
+
+      expect(response).toEqual({})
+    })
+
+    test('should throw an error if the request fails', async () => {
+      vi.spyOn(connection, 'post').mockRejectedValueOnce(new Error('Request failed'))
+
+      vi.spyOn(connection, 'post').mockResolvedValue({
+        data: {
+          error: 'Validation error.',
+          extras: {
+            address: 'Invalid public key provided',
+          },
+        },
+        status: 400,
+      })
+
+      await expect(
+        walletBackend.registerAccount({
+          address: 'invalid_address',
+        })
+      ).rejects.toThrowError()
+    })
+  })
+
+  describe('deregisterAccount', () => {
+    test('should deregister an account from wallet backend service', async () => {
+      vi.spyOn(connection, 'post').mockResolvedValue({
+        data: {},
+        status: 200,
+      })
+
+      const response = await walletBackend.deregisterAccount({
+        address: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE',
+      })
+
+      expect(response).toEqual('')
+    })
+
+    test('should throw an error if the request fails', async () => {
+      vi.spyOn(connection, 'post').mockRejectedValueOnce(new Error('Request failed'))
+
+      vi.spyOn(connection, 'post').mockResolvedValue({
+        data: {
+          error: 'Validation error.',
+          extras: {
+            address: 'Invalid public key provided',
+          },
+        },
+        status: 400,
+      })
+
+      await expect(
+        walletBackend.deregisterAccount({
+          address: 'invalid_address',
+        })
+      ).rejects.toThrowError()
+    })
+  })
+
+  describe('getTransactions', () => {
+    test('should get transactions from wallet backend service', async () => {
+      const mockResponse = {
+        data: {
+          account: {
+            address: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE',
+            transactions: [],
+          },
+        },
+        status: 200,
+      }
+
+      vi.spyOn(connection, 'post').mockResolvedValue(mockResponse)
+
+      const response = await walletBackend.getTransactions({
+        address: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE',
+      })
+
+      expect(response).toEqual(mockResponse.data)
+    })
+
+    test('should throw if the request fails', async () => {
+      vi.spyOn(connection, 'post').mockRejectedValueOnce(new Error('Network error'))
+      await expect(walletBackend.getTransactions({ address: 'CAZDTOP...' })).rejects.toThrowError()
+    })
+
+    test('should handle missing transactions field', async () => {
+      vi.spyOn(connection, 'post').mockResolvedValue({
+        data: { account: { address: 'CAZDTOP...' } },
+        status: 200,
+      })
+      const response = await walletBackend.getTransactions({ address: 'CAZDTOP...' })
+      expect(response.account.transactions).toBeUndefined()
+    })
+  })
+})

--- a/apps/backend/src/interfaces/wallet-backend/index.ts
+++ b/apps/backend/src/interfaces/wallet-backend/index.ts
@@ -1,0 +1,190 @@
+import axios, { AxiosInstance } from 'axios'
+
+import { SingletonBase } from 'api/core/framework/singleton/interface'
+import { AxiosLogger } from 'config/axios-logger'
+import { getValueFromEnv } from 'config/env-utils'
+import { logger } from 'config/logger'
+
+import { generateToken } from './auth/jwt'
+import {
+  AccountRequest,
+  GetTransactionsResponse,
+  TransactionBuildRequest,
+  TransactionBuildResponse,
+  TransactionRequest,
+  TransactionResponse,
+  WalletBackendType,
+} from './types'
+
+export const CONNECTION_TIMEOUT = 10000
+
+// https://petstore.swagger.io/?url=https://raw.githubusercontent.com/stellar/wallet-backend/refs/heads/main/openapi/main.yaml
+export default class WalletBackend extends SingletonBase implements WalletBackendType {
+  private connection: AxiosInstance
+
+  constructor(connection?: AxiosInstance) {
+    super()
+    this.connection =
+      connection ??
+      axios.create({
+        baseURL: getValueFromEnv(
+          'STELLAR_WALLET_BACKEND_URL',
+          'https://wallet-backend-testnet-21ac687b8418.herokuapp.com'
+        ),
+        timeout: CONNECTION_TIMEOUT,
+      })
+
+    const axiosLogger = new AxiosLogger(this.constructor.name)
+    this.connection.interceptors.request.use(axiosLogger.createRequestInterceptor)
+    this.connection.interceptors.response.use(
+      axiosLogger.createFulfilledResponseInterceptor,
+      axiosLogger.createRejectedResponseInterceptor
+    )
+  }
+
+  public async registerAccount(account: AccountRequest): Promise<object> {
+    const registerUrl = `/accounts/${account.address}`
+
+    // TODO: intercept the request, generate and inject the auth token automatically. See line 38 example above.
+    const authToken = await generateToken({
+      methodAndPath: `POST ${registerUrl.split('?')[0]}`.trim(),
+      bodyHash: '',
+    })
+
+    try {
+      const response = await this.connection.post(registerUrl, '', {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      })
+      return response.data
+    } catch (error) {
+      logger.error(error, 'Wallet Backend - Error registering account')
+      throw error
+    }
+  }
+
+  public async deregisterAccount(account: AccountRequest): Promise<object> {
+    const deregisterUrl = `/accounts/${account.address}`
+
+    const authToken = await generateToken({
+      methodAndPath: `DELETE ${deregisterUrl.split('?')[0]}`.trim(),
+      bodyHash: '',
+    })
+
+    try {
+      const response = await this.connection.delete(deregisterUrl, {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      })
+
+      return response.data
+    } catch (error) {
+      logger.error(error, 'Wallet Backend - Error deregistering account')
+      throw error
+    }
+  }
+
+  /**
+   * @param account
+   * @returns
+   */
+  public async getTransactions(account: AccountRequest): Promise<GetTransactionsResponse> {
+    const transactionsUrl = `/graphql/query`
+
+    const query = `
+    query GetAccount($address: String!) {
+      account(address: $address) {
+        address
+        transactions {
+          hash
+          envelopeXdr
+          operations {
+            id
+            operationXdr
+          }
+        }
+      }
+    }
+    `
+
+    const variables = {
+      address: account.address,
+    }
+
+    const authToken = await generateToken({
+      methodAndPath: `POST ${transactionsUrl}`,
+      bodyHash: JSON.stringify({ query, variables }),
+    })
+
+    try {
+      const response = await this.connection.post(
+        transactionsUrl,
+        {
+          query,
+          variables,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${authToken}`,
+          },
+        }
+      )
+      return response.data as GetTransactionsResponse
+    } catch (error) {
+      logger.error(error, 'Wallet Backend - Error fetching transactions')
+      throw error
+    }
+  }
+
+  public async buildTransaction(
+    account: AccountRequest,
+    transactions: TransactionBuildRequest
+  ): Promise<TransactionBuildResponse> {
+    const buildTransactionUrl = '/transactions/build'
+
+    const authToken = await generateToken({
+      // sub: account.address,
+      methodAndPath: `POST ${buildTransactionUrl}`,
+      bodyHash: JSON.stringify(transactions),
+    })
+
+    try {
+      const response = await this.connection.post(buildTransactionUrl, transactions, {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      })
+      return response.data as TransactionBuildResponse
+    } catch (error) {
+      logger.error(error, 'Wallet Backend - Error building transaction')
+      throw error
+    }
+  }
+
+  public async createFeeBumpTransaction(
+    account: AccountRequest,
+    transaction: TransactionRequest
+  ): Promise<TransactionResponse> {
+    const feeBumpTransactionUrl = '/tx/create-fee-bump'
+
+    const authToken = await generateToken({
+      // sub: account.address,
+      methodAndPath: `POST ${feeBumpTransactionUrl}`,
+      bodyHash: JSON.stringify(transaction),
+    })
+
+    try {
+      const response = await this.connection.post(feeBumpTransactionUrl, transaction, {
+        headers: {
+          Authorization: `Bearer ${authToken}`,
+        },
+      })
+      return response.data as TransactionResponse
+    } catch (error) {
+      logger.error(error, 'Wallet Backend - Error building transaction')
+      throw error
+    }
+  }
+}

--- a/apps/backend/src/interfaces/wallet-backend/mock.ts
+++ b/apps/backend/src/interfaces/wallet-backend/mock.ts
@@ -1,0 +1,13 @@
+import { Mocked } from 'vitest'
+
+import { WalletBackendType } from './types'
+
+export function mockWalletBackend(): Mocked<WalletBackendType> {
+  return {
+    registerAccount: vi.fn(),
+    deregisterAccount: vi.fn(),
+    getTransactions: vi.fn(),
+    buildTransaction: vi.fn(),
+    createFeeBumpTransaction: vi.fn(),
+  }
+}

--- a/apps/backend/src/interfaces/wallet-backend/types.ts
+++ b/apps/backend/src/interfaces/wallet-backend/types.ts
@@ -1,0 +1,56 @@
+export type AccountRequest = {
+  address: string
+}
+
+export type TransactionRequest = {
+  transaction: string
+}
+
+export type TransactionResponse = {
+  // TODO: change to Transaction type when wallet-backend is updated
+  transaction: string
+  networkPassphrase: string
+}
+
+// https://petstore.swagger.io/?url=https://raw.githubusercontent.com/stellar/wallet-backend/refs/heads/main/openapi/main.yaml#/Transactions/post_transactions_build
+export type TransactionOperation = {
+  // TODO: change to Operation type when wallet-backend is updated
+  operations: string[]
+  timeout: number
+}
+
+export type TransactionBuildRequest = {
+  transactions: TransactionOperation[]
+}
+
+export type TransactionBuildResponse = {
+  transactionXdrs: string[]
+}
+
+export interface Operation {
+  id: string
+  operationXdr: string
+}
+
+export interface Transaction {
+  hash: string
+  envelopeXdr: string
+  operations: Operation[]
+}
+
+export interface AccountWithTransactions {
+  address: string
+  transactions: Transaction[]
+}
+
+export interface GetTransactionsResponse {
+  account: AccountWithTransactions
+}
+
+export type WalletBackendType = {
+  registerAccount(account: AccountRequest): Promise<object>
+  deregisterAccount(account: AccountRequest): Promise<object>
+  getTransactions(account: AccountRequest): Promise<GetTransactionsResponse>
+  buildTransaction(account: AccountRequest, transactions: TransactionBuildRequest): Promise<TransactionBuildResponse>
+  createFeeBumpTransaction(account: AccountRequest, transactions: TransactionRequest): Promise<TransactionResponse>
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -55,6 +55,7 @@
         "dotenv-safe": "^9.1.0",
         "express": "^4.21.1",
         "express-async-errors": "^3.1.1",
+        "jose": "^6.0.12",
         "jsonwebtoken": "^9.0.2",
         "minimatch": "^3.1.2",
         "pg": "^8.16.3",
@@ -11755,6 +11756,15 @@
       "license": "MIT",
       "bin": {
         "jiti": "bin/jiti.js"
+      }
+    },
+    "node_modules/jose": {
+      "version": "6.0.12",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-6.0.12.tgz",
+      "integrity": "sha512-T8xypXs8CpmiIi78k0E+Lk7T2zlK4zDyg+o1CZ4AkOHgDg98ogdP2BeZ61lTFKFyoEwJ9RgAgN+SdM3iPgNonQ==",
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "node_modules/js-tokens": {


### PR DESCRIPTION
### What

Register account on wallet-backend service after the wallet address is recovered from SDP.

### Why

Necessary to index wallet transaction history data within wallet backend service db.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
