### PR TITLE
feature: Register wallet within wallet-backend service

### DIFF
--- a/apps/backend/src/api/embedded-wallets/use-cases/create-wallet/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/create-wallet/index.ts
@@ -14,7 +14,6 @@ import { UnauthorizedException } from 'errors/exceptions/unauthorized'
 import { generateToken } from 'interfaces/jwt'
 import SDPEmbeddedWallets from 'interfaces/sdp-embedded-wallets'
 import { SDPEmbeddedWalletsType, WalletStatus } from 'interfaces/sdp-embedded-wallets/types'
-import WalletBackend from 'interfaces/wallet-backend'
 import { WebAuthnChallengeService } from 'interfaces/webauthn-challenge'
 import { IWebauthnChallengeService } from 'interfaces/webauthn-challenge/types'
 
@@ -27,21 +26,18 @@ export class CreateWallet extends UseCaseBase implements IUseCaseHttp<ResponseSc
   private passkeyRepository: PasskeyRepositoryType
   private webauthnChallengeService: IWebauthnChallengeService
   private sdpEmbeddedWallets: SDPEmbeddedWalletsType
-  private walletBackend: WalletBackend
 
   constructor(
     userRepository?: UserRepositoryType,
     passkeyRepository?: PasskeyRepositoryType,
     webauthnChallengeService?: IWebauthnChallengeService,
-    sdpEmbeddedWallets?: SDPEmbeddedWalletsType,
-    walletBackend?: WalletBackend
+    sdpEmbeddedWallets?: SDPEmbeddedWalletsType
   ) {
     super()
     this.userRepository = userRepository || UserRepository.getInstance()
     this.passkeyRepository = passkeyRepository || PasskeyRepository.getInstance()
     this.webauthnChallengeService = webauthnChallengeService || WebAuthnChallengeService.getInstance()
     this.sdpEmbeddedWallets = sdpEmbeddedWallets || SDPEmbeddedWallets.getInstance()
-    this.walletBackend = walletBackend || WalletBackend.getInstance()
   }
 
   parseResponseMessage(status: WalletStatus): string {

--- a/apps/backend/src/api/embedded-wallets/use-cases/create-wallet/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/create-wallet/index.ts
@@ -14,6 +14,7 @@ import { UnauthorizedException } from 'errors/exceptions/unauthorized'
 import { generateToken } from 'interfaces/jwt'
 import SDPEmbeddedWallets from 'interfaces/sdp-embedded-wallets'
 import { SDPEmbeddedWalletsType, WalletStatus } from 'interfaces/sdp-embedded-wallets/types'
+import WalletBackend from 'interfaces/wallet-backend'
 import { WebAuthnChallengeService } from 'interfaces/webauthn-challenge'
 import { IWebauthnChallengeService } from 'interfaces/webauthn-challenge/types'
 
@@ -26,18 +27,21 @@ export class CreateWallet extends UseCaseBase implements IUseCaseHttp<ResponseSc
   private passkeyRepository: PasskeyRepositoryType
   private webauthnChallengeService: IWebauthnChallengeService
   private sdpEmbeddedWallets: SDPEmbeddedWalletsType
+  private walletBackend: WalletBackend
 
   constructor(
     userRepository?: UserRepositoryType,
     passkeyRepository?: PasskeyRepositoryType,
     webauthnChallengeService?: IWebauthnChallengeService,
-    sdpEmbeddedWallets?: SDPEmbeddedWalletsType
+    sdpEmbeddedWallets?: SDPEmbeddedWalletsType,
+    walletBackend?: WalletBackend
   ) {
     super()
     this.userRepository = userRepository || UserRepository.getInstance()
     this.passkeyRepository = passkeyRepository || PasskeyRepository.getInstance()
     this.webauthnChallengeService = webauthnChallengeService || WebAuthnChallengeService.getInstance()
     this.sdpEmbeddedWallets = sdpEmbeddedWallets || SDPEmbeddedWallets.getInstance()
+    this.walletBackend = walletBackend || WalletBackend.getInstance()
   }
 
   parseResponseMessage(status: WalletStatus): string {

--- a/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.test.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.test.ts
@@ -72,14 +72,19 @@ describe('GetWallet', () => {
       status: WalletStatus.SUCCESS,
       contract_address: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE',
     } as CheckWalletStatusResponse)
-    mockedUserRepository.updateUser.mockResolvedValue({ ...user, contractAddress: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE' } as User)
+    mockedUserRepository.updateUser.mockResolvedValue({
+      ...user,
+      contractAddress: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE',
+    } as User)
 
     const payload = { id: 'user-123' }
     const result = await getWallet.handle(payload)
     expect(result.data.status).toBe(WalletStatus.SUCCESS)
     expect(result.data.address).toBe('CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE')
     expect(mockedSDPEmbeddedWallets.checkWalletStatus).toHaveBeenCalledTimes(2)
-    expect(mockedUserRepository.updateUser).toHaveBeenCalledWith('user-123', { contractAddress: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE' })
+    expect(mockedUserRepository.updateUser).toHaveBeenCalledWith('user-123', {
+      contractAddress: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE',
+    })
   })
 
   it('should return pending status if wallet is not created after retries', async () => {

--- a/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.test.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.test.ts
@@ -70,16 +70,16 @@ describe('GetWallet', () => {
     } as CheckWalletStatusResponse)
     mockedSDPEmbeddedWallets.checkWalletStatus.mockResolvedValueOnce({
       status: WalletStatus.SUCCESS,
-      contract_address: 'new-wallet-address',
+      contract_address: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE',
     } as CheckWalletStatusResponse)
-    mockedUserRepository.updateUser.mockResolvedValue({ ...user, contractAddress: 'new-wallet-address' } as User)
+    mockedUserRepository.updateUser.mockResolvedValue({ ...user, contractAddress: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE' } as User)
 
     const payload = { id: 'user-123' }
     const result = await getWallet.handle(payload)
     expect(result.data.status).toBe(WalletStatus.SUCCESS)
-    expect(result.data.address).toBe('new-wallet-address')
+    expect(result.data.address).toBe('CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE')
     expect(mockedSDPEmbeddedWallets.checkWalletStatus).toHaveBeenCalledTimes(2)
-    expect(mockedUserRepository.updateUser).toHaveBeenCalledWith('user-123', { contractAddress: 'new-wallet-address' })
+    expect(mockedUserRepository.updateUser).toHaveBeenCalledWith('user-123', { contractAddress: 'CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE' })
   })
 
   it('should return pending status if wallet is not created after retries', async () => {


### PR DESCRIPTION
### What

Register account on wallet-backend service after the wallet address is recovered from SDP.

### Why

Necessary to index wallet transaction history data within wallet backend service db.

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
