### PR TITLE
fix: change the logic on the register of account within wallet backend

### DIFF
--- a/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.ts
@@ -69,6 +69,9 @@ export class GetWallet extends UseCaseBase implements IUseCaseHttp<ResponseSchem
 
     // Check if user already has a wallet
     if (user.contractAddress) {
+      // Register the account in the wallet backend service
+      await this.walletBackend.registerAccount({ address: user.contractAddress })
+
       // Get wallet balance
       const { simulationResponse } = await this.sorobanService.simulateContract({
         contractId: STELLAR.TOKEN_CONTRACT.NATIVE, // TODO: get balance for another assets?
@@ -96,7 +99,7 @@ export class GetWallet extends UseCaseBase implements IUseCaseHttp<ResponseSchem
         // Update user with the new wallet address
         user = await this.userRepository.updateUser(user.userId, { contractAddress: updatedStatus.contract_address })
 
-        // Register the account in the wallet backend
+        // Register the account in the wallet backend service
         await this.walletBackend.registerAccount({ address: updatedStatus.contract_address })
         break
       }


### PR DESCRIPTION
### What

Change the logic on the register of account within wallet backend.

### Why

To register the account on the wallet/contract address creation and on getting wallet data.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
