### PR TITLE
Refactor: always send wallet info on get wallet

### DIFF
--- a/apps/backend/src/api/embedded-wallets/constants/messages.ts
+++ b/apps/backend/src/api/embedded-wallets/constants/messages.ts
@@ -4,6 +4,8 @@ export const messages = {
   USER_NOT_FOUND_BY_ID: "We couldn't find an user with that id",
   USER_ALREADY_HAS_WALLET: 'You already have a wallet linked to your account',
   USER_DOES_NOT_HAVE_WALLET: 'You do not have a wallet linked to your account',
+  UNKNOWN_CONTRACT_ADDRESS_CREATION_ERROR:
+    'Unknown error occurred while registering your wallet. Please try again later',
   USER_DOES_NOT_HAVE_PASSKEYS: 'You do not have any passkeys registered. Try recovering your wallet',
   UNABLE_TO_COMPLETE_PASSKEY_REGISTRATION:
     "We couldn't complete your passkey registration. Try again or use a different device",

--- a/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/types.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/types.ts
@@ -5,9 +5,9 @@ import { WalletStatus } from 'interfaces/sdp-embedded-wallets/types'
 
 export const ParseSchema = z.object({
   status: z.nativeEnum(WalletStatus),
-  address: z.string().optional(),
-  balance: z.string().optional(),
-  email: z.string().optional(),
+  address: z.string(),
+  balance: z.number(),
+  email: z.string().email(),
 })
 
 export type ParseSchemaT = z.infer<typeof ParseSchema>

--- a/apps/web/src/app/wallet/pages/home/index.tsx
+++ b/apps/web/src/app/wallet/pages/home/index.tsx
@@ -9,6 +9,7 @@ export const Home = () => {
   const navigate = useNavigate()
 
   const getWallet = useGetWallet()
+  const walletData = getWallet.data?.data
 
   const handlePayClick = () => navigate({ to: WalletPagesPath.SCAN })
 
@@ -26,7 +27,7 @@ export const Home = () => {
   return (
     <HomeTemplate
       isLoadingBalance={getWallet.isPending}
-      balanceAmount={0}
+      balanceAmount={walletData?.balance || 0}
       onNavbarButtonClick={handleNavbarButtonClick}
       onPayClick={handlePayClick}
     />

--- a/apps/web/src/app/wallet/services/wallet/types.ts
+++ b/apps/web/src/app/wallet/services/wallet/types.ts
@@ -8,9 +8,9 @@ export interface IWalletService {
 
 export type GetWalletResult = IHTTPResponse<{
   status: WalletStatus
-  address?: string
-  email?: string
-  balance?: string
+  address: string
+  email: string
+  balance: number
 }>
 
 export interface Transaction {


### PR DESCRIPTION
### What

- Returns wallet balance as a number (human readable, losing precision ⚠️ )
    - (web) renders wallet balance on the wallet home page
- Always return wallet info on `GET get-wallet`
    - If for some reason the contract address are not available, it will throw an exception

### Why

- Reduces web friction for new users
- Leave the web locale format the asset

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [ ] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
