### PR TITLE
refac: change zod validation

### DIFF
--- a/apps/backend/src/api/core/framework/use-case/base.ts
+++ b/apps/backend/src/api/core/framework/use-case/base.ts
@@ -51,6 +51,7 @@ export abstract class UseCaseBase<UseCaseResponse extends BaseResponseSchema = B
   protected validate<T extends ZodType>(payload: unknown, schema: T): z.infer<typeof schema> {
     const request: { success: boolean; error?: ZodError; data?: typeof payload } = schema.safeParse(payload)
     if (!request.success && request.error instanceof ZodError) {
+      // console.log('ERROR >>>', request.error)
       throw new ZodValidationException(request.error)
     }
     return request.data as z.infer<typeof schema>

--- a/apps/backend/src/errors/exceptions/zod-validation.test.ts
+++ b/apps/backend/src/errors/exceptions/zod-validation.test.ts
@@ -17,24 +17,66 @@ describe('ZodValidationException', () => {
 
   it('should correctly map ZodError issues to fields', () => {
     const zodIssues: ZodIssue[] = [
-      { path: ['field1'], message: 'Invalid field1', code: 'invalid_type' } as ZodIssue,
-      { path: ['field2'], message: 'Invalid field2', code: 'invalid_type' } as ZodIssue,
-      { path: ['field1'], message: 'Another issue with field1', code: 'custom' },
+      {
+        path: ['field1'],
+        message: 'Invalid field1',
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'number',
+      } as ZodIssue,
+      {
+        path: ['field2'],
+        message: 'Invalid field2',
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'undefined',
+      } as ZodIssue,
+      {
+        path: ['field1'],
+        message: 'Another issue with field1',
+        code: 'custom',
+      } as ZodIssue,
     ]
     const zodError = new ZodError(zodIssues)
     const exception = new ZodValidationException(zodError)
 
     expect(exception.fields).toEqual({
       field1: [
-        { path: ['field1'], message: 'Invalid field1', code: 'invalid_type' },
-        { path: ['field1'], message: 'Another issue with field1', code: 'custom' },
+        {
+          path: ['field1'],
+          message: 'Invalid field1',
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'number',
+        },
+        {
+          path: ['field1'],
+          message: 'Another issue with field1',
+          code: 'custom',
+        },
       ],
-      field2: [{ path: ['field2'], message: 'Invalid field2', code: 'invalid_type' }],
+      field2: [
+        {
+          path: ['field2'],
+          message: 'Invalid field2',
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+        },
+      ],
     })
   })
 
   it('should correctly generate the payload', () => {
-    const zodIssues: ZodIssue[] = [{ path: ['field1'], message: 'Invalid field1', code: 'invalid_type' } as ZodIssue]
+    const zodIssues: ZodIssue[] = [
+      {
+        path: ['field1'],
+        message: 'Invalid field1',
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'undefined',
+      } as ZodIssue,
+    ]
     const zodError = new ZodError(zodIssues)
     const exception = new ZodValidationException(zodError)
 
@@ -42,7 +84,15 @@ describe('ZodValidationException', () => {
       message: exception.message,
       code: ErrorCode.VALIDATION_ERROR,
       fields: {
-        field1: [{ path: ['field1'], message: 'Invalid field1', code: 'invalid_type' }],
+        field1: [
+          {
+            path: ['field1'],
+            message: 'Invalid field1',
+            code: 'invalid_type',
+            expected: 'string',
+            received: 'undefined',
+          },
+        ],
       },
     })
   })
@@ -53,5 +103,153 @@ describe('ZodValidationException', () => {
 
     expect(exception.fields).toEqual({})
     expect(exception.payload.fields).toEqual({})
+  })
+
+  it('should handle union errors with empty paths', () => {
+    // Create nested ZodErrors for union errors
+    const unionError1 = new ZodError([
+      {
+        path: [],
+        message: 'Expected object, received string',
+        code: 'invalid_type',
+        expected: 'object',
+        received: 'string',
+      } as ZodIssue,
+    ])
+
+    const unionError2 = new ZodError([
+      {
+        path: [],
+        message: 'Expected object, received number',
+        code: 'invalid_type',
+        expected: 'object',
+        received: 'number',
+      } as ZodIssue,
+    ])
+
+    const zodIssues: ZodIssue[] = [
+      {
+        path: [],
+        message: 'Invalid input',
+        code: 'invalid_union',
+        unionErrors: [unionError1, unionError2],
+      } as ZodIssue,
+      {
+        path: ['field1'],
+        message: 'Invalid field1',
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'undefined',
+      } as ZodIssue,
+    ]
+    const zodError = new ZodError(zodIssues)
+    const exception = new ZodValidationException(zodError)
+
+    expect(exception.fields).toEqual({
+      _union: [
+        {
+          path: [],
+          message: 'Invalid input',
+          code: 'invalid_union',
+          unionErrors: [unionError1, unionError2],
+        },
+      ],
+      field1: [
+        {
+          path: ['field1'],
+          message: 'Invalid field1',
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+        },
+      ],
+    })
+  })
+
+  it('should produce the exact format requested', () => {
+    const zodIssues: ZodIssue[] = [
+      {
+        path: ['email'],
+        message: 'Required',
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'undefined',
+      } as ZodIssue,
+      {
+        path: ['registration_response_json'],
+        message: 'Required',
+        code: 'invalid_type',
+        expected: 'string',
+        received: 'undefined',
+      } as ZodIssue,
+    ]
+    const zodError = new ZodError(zodIssues)
+    const exception = new ZodValidationException(zodError)
+
+    expect(exception.payload.fields).toEqual({
+      email: [
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['email'],
+          message: 'Required',
+        },
+      ],
+      registration_response_json: [
+        {
+          code: 'invalid_type',
+          expected: 'string',
+          received: 'undefined',
+          path: ['registration_response_json'],
+          message: 'Required',
+        },
+      ],
+    })
+  })
+
+  it('should produce union errors in the same format', () => {
+    // Create nested ZodErrors for union errors
+    const unionError1 = new ZodError([
+      {
+        path: [],
+        message: 'Expected object, received string',
+        code: 'invalid_type',
+        expected: 'object',
+        received: 'string',
+      } as ZodIssue,
+    ])
+
+    const unionError2 = new ZodError([
+      {
+        path: [],
+        message: 'Expected object, received number',
+        code: 'invalid_type',
+        expected: 'object',
+        received: 'number',
+      } as ZodIssue,
+    ])
+
+    const zodIssues: ZodIssue[] = [
+      {
+        path: [],
+        message: 'Invalid input',
+        code: 'invalid_union',
+        unionErrors: [unionError1, unionError2],
+      } as ZodIssue,
+    ]
+    const zodError = new ZodError(zodIssues)
+    const exception = new ZodValidationException(zodError)
+
+    expect(exception.payload.fields).toEqual({
+      _union: [
+        {
+          code: 'invalid_union',
+          message: 'Invalid input',
+          path: [],
+          unionErrors: [unionError1, unionError2],
+        },
+      ],
+    })
   })
 })

--- a/apps/backend/src/errors/exceptions/zod-validation.ts
+++ b/apps/backend/src/errors/exceptions/zod-validation.ts
@@ -21,9 +21,17 @@ export class ZodValidationException extends BaseException {
 
   get fields(): FieldsErrors {
     return this.zodError.errors.reduce((fields, error) => {
-      for (const path of error.path) {
-        fields[path] ??= []
-        fields[path].push(error)
+      // Handle union errors where path is empty
+      if (error.path.length === 0) {
+        // Add union errors to a special "_union" field for root-level errors
+        fields['_union'] ??= []
+        fields['_union'].push(error)
+      } else {
+        // Handle regular field errors
+        for (const path of error.path) {
+          fields[path] ??= []
+          fields[path].push(error)
+        }
       }
       return fields
     }, {} as FieldsErrors)


### PR DESCRIPTION
### What

Change ZodValidationException to handle union exceptions

### Why

Change ZodValidationException to deal with union errors when using zod.union() schemas

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
