### PR TITLE
Refactor(web): transaction history order and send receive rule

### DIFF
--- a/apps/web/src/app/auth/constants/storage.ts
+++ b/apps/web/src/app/auth/constants/storage.ts
@@ -4,3 +4,4 @@ export const AUTH_TOKEN_CHANNEL_KEY = `${APP_NAME}/broadcast-channel/auth-token`
 
 export const ACCESS_TOKEN_STORAGE_KEY = `${APP_NAME}/access-token`
 export const EMAIL_STORAGE_KEY = `${APP_NAME}/email`
+export const WALLET_ADDRESS_STORAGE_KEY = `${APP_NAME}/wallet-address`

--- a/apps/web/src/app/wallet/domain/models/transaction.ts
+++ b/apps/web/src/app/wallet/domain/models/transaction.ts
@@ -5,4 +5,7 @@ export interface Transaction {
   amount: number
   asset: string
   date: string
+  fromAddress?: string
+  toAddress?: string
+  sendOrReceive?: 'send' | 'receive'
 }

--- a/apps/web/src/app/wallet/domain/use-cases/get-wallet/index.ts
+++ b/apps/web/src/app/wallet/domain/use-cases/get-wallet/index.ts
@@ -1,0 +1,27 @@
+import { UseCaseBase } from 'src/app/core/framework/use-case/base'
+import { walletService } from 'src/app/wallet/services'
+import { IWalletService } from 'src/app/wallet/services/wallet/types'
+import { useWalletAddressStore } from 'src/app/wallet/store'
+
+import { GetWalletResult } from './types'
+
+export class GetWalletUseCase extends UseCaseBase<GetWalletResult> {
+  private walletService: IWalletService
+
+  constructor(walletService: IWalletService) {
+    super()
+    this.walletService = walletService
+  }
+
+  async handle(): Promise<GetWalletResult> {
+    const { data } = await this.walletService.getWallet()
+
+    useWalletAddressStore.getState().setWalletAddress(data.address)
+
+    return data
+  }
+}
+
+const getWalletUseCase = new GetWalletUseCase(walletService)
+
+export { getWalletUseCase }

--- a/apps/web/src/app/wallet/domain/use-cases/get-wallet/types.ts
+++ b/apps/web/src/app/wallet/domain/use-cases/get-wallet/types.ts
@@ -1,0 +1,8 @@
+import { WalletStatus } from 'src/app/auth/domain/models/user'
+
+export type GetWalletResult = {
+  status: WalletStatus
+  address: string
+  email: string
+  balance: number
+}

--- a/apps/web/src/app/wallet/hooks/use-init-transfer.ts
+++ b/apps/web/src/app/wallet/hooks/use-init-transfer.ts
@@ -65,7 +65,7 @@ export const useInitTransfer = ({ params, enabled }: InitTransferProps) => {
           key: transactionDetailsModalKey,
           variantOptions: {
             variant: 'transaction-details',
-            source: {
+            vendor: {
               name: data.vendor?.name || data.vendor?.wallet_address || 'Unknown Source',
               imageUri: data.vendor?.profile_image,
             },

--- a/apps/web/src/app/wallet/pages/home/index.tsx
+++ b/apps/web/src/app/wallet/pages/home/index.tsx
@@ -17,7 +17,7 @@ export const Home = () => {
     enabled: !loaderDeps.shouldInitTransfer,
   })
 
-  const walletData = getWallet.data?.data
+  const walletData = getWallet.data
 
   useInitTransfer({
     params: search,

--- a/apps/web/src/app/wallet/pages/profile/index.tsx
+++ b/apps/web/src/app/wallet/pages/profile/index.tsx
@@ -6,11 +6,13 @@ import { useAccessTokenStore, useEmailStore } from 'src/app/auth/store'
 import { ProfileTemplate } from './template'
 import { useGetWallet } from '../../queries/use-get-wallet'
 import { WalletPagesPath } from '../../routes/types'
+import { useWalletAddressStore } from '../../store'
 
 export const Profile = () => {
   const navigate = useNavigate()
   const { clearAccessToken } = useAccessTokenStore()
   const { clearEmail } = useEmailStore()
+  const { clearWalletAddress } = useWalletAddressStore()
   const canGoBack = useCanGoBack()
   const router = useRouter()
 
@@ -18,8 +20,8 @@ export const Profile = () => {
   const { data: walletData, isPending: isLoadingProfile } = useGetWallet()
 
   // Extract data from the API response
-  const email = walletData?.data.email || ''
-  const fullWalletAddress = walletData?.data.address || ''
+  const email = walletData?.email || ''
+  const fullWalletAddress = walletData?.address || ''
 
   const handleGoBack = () => {
     if (canGoBack) router.history.back()
@@ -31,6 +33,7 @@ export const Profile = () => {
     // Clear session data and redirect to welcome page
     clearAccessToken(AuthPagesPath.WELCOME)
     clearEmail()
+    clearWalletAddress()
   }
 
   return (

--- a/apps/web/src/app/wallet/pages/transactions/index.tsx
+++ b/apps/web/src/app/wallet/pages/transactions/index.tsx
@@ -8,6 +8,7 @@ import { TransactionsTemplate } from './template'
 import { Transaction } from '../../domain/models/transaction'
 import { useGetTransactionHistory } from '../../queries/use-get-transaction-history'
 import { WalletPagesPath } from '../../routes/types'
+import { mapTxVendorName } from '../../utils'
 
 export const Transactions = () => {
   const navigate = useNavigate()
@@ -29,8 +30,8 @@ export const Transactions = () => {
       variantOptions: {
         variant: 'transaction-details',
         date: tx.date,
-        source: {
-          name: tx.vendor,
+        vendor: {
+          name: mapTxVendorName(tx),
         },
         amount: {
           value: tx.amount,

--- a/apps/web/src/app/wallet/pages/transactions/template.tsx
+++ b/apps/web/src/app/wallet/pages/transactions/template.tsx
@@ -8,6 +8,7 @@ import { a } from 'src/interfaces/cms/useAssets'
 import { c } from 'src/interfaces/cms/useContent'
 
 import { Transaction } from '../../domain/models/transaction'
+import { mapTxVendorName } from '../../utils'
 
 interface TransactionsTemplateProps {
   isLoadingTransactionHistory: boolean
@@ -18,15 +19,27 @@ interface TransactionsTemplateProps {
 
 // Helper to group transactions by date (YYYY-MM-DD)
 function groupByDate(transactions: Transaction[]) {
-  return transactions.reduce(
+  const grouped: Record<string, Transaction[]> = transactions.reduce(
     (acc, tx) => {
-      const dateKey = new Date(tx.date).toLocaleDateString('en-US', { year: 'numeric', month: 'short', day: '2-digit' })
+      const dateKey = new Date(tx.date).toLocaleDateString('en-US', {
+        year: 'numeric',
+        month: 'short',
+        day: '2-digit',
+      })
       if (!acc[dateKey]) acc[dateKey] = []
       acc[dateKey].push(tx)
       return acc
     },
     {} as Record<string, Transaction[]>
   )
+
+  // Sort transactions by date under each group
+  const sorted: Record<string, Transaction[]> = {}
+  Object.keys(grouped).forEach(dateKey => {
+    sorted[dateKey] = grouped[dateKey].sort((a, b) => new Date(b.date).getTime() - new Date(a.date).getTime())
+  })
+
+  return sorted
 }
 
 export const TransactionsTemplate = ({
@@ -40,6 +53,12 @@ export const TransactionsTemplate = ({
   const dateOrder = Object.keys(grouped).sort((a, b) => new Date(b).getTime() - new Date(a).getTime())
 
   const TransactionListItem = ({ tx }: { tx: Transaction }) => {
+    let amountSignal = ''
+
+    if (tx.sendOrReceive === 'send') {
+      amountSignal = '-'
+    } else if (tx.sendOrReceive === 'receive') amountSignal = '+'
+
     return (
       <button
         key={tx.hash}
@@ -56,12 +75,12 @@ export const TransactionsTemplate = ({
         <div className="flex w-full justify-between items-center">
           <div className="flex-[0.5] text-left truncate">
             <Text as="span" size="md" className="font-medium text-text text-base leading-6">
-              {createShortStellarAddress(tx.vendor, { onlyValidAddress: true })}
+              {createShortStellarAddress(mapTxVendorName(tx), { onlyValidAddress: true })}
             </Text>
           </div>
           <div className="flex-[0.325] text-right truncate">
             <span className="font-medium text-text text-base leading-6">
-              {tx.amount > 0 ? '+' : ''}
+              {amountSignal}
               {formatNumber(tx.amount, 'en-US', 14, 2, 2)}
             </span>
           </div>

--- a/apps/web/src/app/wallet/queries/use-get-wallet.ts
+++ b/apps/web/src/app/wallet/queries/use-get-wallet.ts
@@ -1,16 +1,15 @@
 import { queryOptions, useQuery, UseQueryOptions, UseQueryResult } from '@tanstack/react-query'
 
-import { walletService } from 'src/app/wallet/services'
-import { GetWalletResult } from 'src/app/wallet/services/wallet/types'
-
 import { WalletQueryKeys } from './query-keys'
+import { getWalletUseCase } from '../domain/use-cases/get-wallet'
+import { GetWalletResult } from '../domain/use-cases/get-wallet/types'
 
 type UseCaseResult = GetWalletResult
 
 export const getWallet = () =>
   queryOptions<UseCaseResult, Error>({
     queryKey: [WalletQueryKeys.GetWallet],
-    queryFn: () => walletService.getWallet(),
+    queryFn: () => getWalletUseCase.handle(),
     staleTime: 1 * 60 * 1000, // 1 minute
   })
 

--- a/apps/web/src/app/wallet/store/index.ts
+++ b/apps/web/src/app/wallet/store/index.ts
@@ -1,0 +1,1 @@
+export * from './wallet-address'

--- a/apps/web/src/app/wallet/store/wallet-address/index.ts
+++ b/apps/web/src/app/wallet/store/wallet-address/index.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+
+import { EMAIL_STORAGE_KEY } from 'src/app/auth/constants/storage'
+
+import { WalletAddressStoreFields, WalletAddressStoreState } from './types'
+
+const INITIAL_STATE: WalletAddressStoreFields = {
+  address: null,
+}
+
+export const useWalletAddressStore = create<WalletAddressStoreState>()(
+  persist(
+    set => ({
+      ...INITIAL_STATE,
+      setWalletAddress: address => set({ address }),
+      clearWalletAddress: () => set({ address: null }),
+    }),
+    {
+      name: EMAIL_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+)

--- a/apps/web/src/app/wallet/store/wallet-address/types.ts
+++ b/apps/web/src/app/wallet/store/wallet-address/types.ts
@@ -1,0 +1,10 @@
+export type WalletAddressStoreFields = {
+  address: string | null
+}
+
+export type WalletAddressStoreActions = {
+  setWalletAddress: (address: string | null) => void
+  clearWalletAddress: () => void
+}
+
+export type WalletAddressStoreState = WalletAddressStoreFields & WalletAddressStoreActions

--- a/apps/web/src/app/wallet/store/wallet-address/wallet-address.store.test.ts
+++ b/apps/web/src/app/wallet/store/wallet-address/wallet-address.store.test.ts
@@ -1,0 +1,11 @@
+import { renderHook } from '@testing-library/react'
+
+import { useWalletAddressStore } from '../wallet-address'
+
+describe('EmailStore', () => {
+  it('creates an wallet-address store with initial state empty', () => {
+    const store = renderHook(() => useWalletAddressStore()).result.current
+
+    expect(store.address).toBeNull()
+  })
+})

--- a/apps/web/src/app/wallet/utils/index.ts
+++ b/apps/web/src/app/wallet/utils/index.ts
@@ -1,0 +1,1 @@
+export * from './map-tx-vendor-name'

--- a/apps/web/src/app/wallet/utils/map-tx-vendor-name/index.ts
+++ b/apps/web/src/app/wallet/utils/map-tx-vendor-name/index.ts
@@ -1,0 +1,11 @@
+import { Transaction } from '../../domain/models/transaction'
+
+export const mapTxVendorName = (tx: Transaction): string => {
+  if (tx.vendor !== tx.toAddress && tx.vendor !== tx.fromAddress) return tx.vendor
+
+  if (tx.sendOrReceive === 'send' && tx.toAddress) return tx.toAddress
+
+  if (tx.sendOrReceive === 'receive' && tx.fromAddress) return tx.fromAddress
+
+  return tx.vendor
+}

--- a/apps/web/src/components/organisms/modal/variants/transaction-details.tsx
+++ b/apps/web/src/components/organisms/modal/variants/transaction-details.tsx
@@ -10,7 +10,7 @@ import { AssetAmount, NavigateButton } from '../../../molecules'
 export type ModalTransactionDetailsProps = {
   variant: Extract<ModalVariants, 'transaction-details'>
   date?: string
-  source: {
+  vendor: {
     name: string
     imageUri?: string
   }
@@ -25,7 +25,7 @@ export type ModalTransactionDetailsProps = {
 
 export const ModalTransactionDetails = ({
   date,
-  source,
+  vendor,
   amount,
   availableBalance,
   transactionHash,
@@ -116,10 +116,10 @@ export const ModalTransactionDetails = ({
       <NavigateButton className="absolute -top-10 right-0" type="close" variant="ghost" onClick={onClose} />
 
       {/* Top Section with Date, Type, and Amount */}
-      {source.imageUri ? (
-        <TopComponentWithImage name={source.name} imageUri={source.imageUri} />
+      {vendor.imageUri ? (
+        <TopComponentWithImage name={vendor.name} imageUri={vendor.imageUri} />
       ) : (
-        <TopComponentWithoutImage name={source.name} />
+        <TopComponentWithoutImage name={vendor.name} />
       )}
 
       {/* Transaction ID Section */}


### PR DESCRIPTION
### What

- Refactors the transaction history order (and add send/receive rule)
- Bonus: move get wallet to use case (in order to store wallet address on local storage)

### Why

- Leave the most recents tx at the top and properly render vendor name (or address)

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
