### PR TITLE
Feature(backend): Add airdrop claim options + complete flow

### DIFF
--- a/apps/backend/src/api/embedded-wallets/constants/messages.ts
+++ b/apps/backend/src/api/embedded-wallets/constants/messages.ts
@@ -20,4 +20,7 @@ export const messages = {
   UNABLE_TO_FIND_SOROBAN_CUSTOM_METADATA:
     "Something went wrong and we couldn't find your transaction. Please start over to try again",
   UNABLE_TO_FIND_ASSET_OR_CONTRACT: "We couldn't find the asset or contract for this transaction.",
+  AIRDROP_PROOF_NOT_FOUND: 'You are not eligible for this airdrop or the proof could not be found.',
+  AIRDROP_ALREADY_CLAIMED: 'This airdrop has already been claimed for your address.',
+  UNABLE_TO_EXECUTE_AIRDROP_CLAIM: 'The airdrop claim could not be executed. Please try again later.',
 }

--- a/apps/backend/src/api/embedded-wallets/docs.ts
+++ b/apps/backend/src/api/embedded-wallets/docs.ts
@@ -1,3 +1,5 @@
+import AirdropCompleteDocs from 'api/embedded-wallets/use-cases/airdrop-complete/index.docs'
+import AirdropOptionsDocs from 'api/embedded-wallets/use-cases/airdrop-options/index.docs'
 import CreateWalletDocs from 'api/embedded-wallets/use-cases/create-wallet/index.docs'
 import CreateWalletOptionsDocs from 'api/embedded-wallets/use-cases/create-wallet-options/index.docs'
 import GenerateRecoveryLinkDocs from 'api/embedded-wallets/use-cases/generate-recovery-link/index.docs'
@@ -9,6 +11,8 @@ import LogInOptionsDocs from 'api/embedded-wallets/use-cases/login-options/index
 import RecoverWalletDocs from 'api/embedded-wallets/use-cases/recover-wallet/index.docs'
 import RecoverWalletOptionsDocs from 'api/embedded-wallets/use-cases/recover-wallet-options/index.docs'
 import ResendInviteDocs from 'api/embedded-wallets/use-cases/resend-invite/index.docs'
+import TransferDocs from 'api/embedded-wallets/use-cases/transfer/index.docs'
+import TransferOptionsDocs from 'api/embedded-wallets/use-cases/transfer-options/index.docs'
 import ValidateRecoveryLinkDocs from 'api/embedded-wallets/use-cases/validate-recovery-link/index.docs'
 
 export default {
@@ -47,5 +51,17 @@ export default {
   },
   '/api/embedded-wallets/resend-invite': {
     ...ResendInviteDocs,
+  },
+  '/api/embedded-wallets/transfer/options': {
+    ...TransferOptionsDocs,
+  },
+  '/api/embedded-wallets/transfer/complete': {
+    ...TransferDocs,
+  },
+  '/api/embedded-wallets/airdrop/options': {
+    ...AirdropOptionsDocs,
+  },
+  '/api/embedded-wallets/airdrop/complete': {
+    ...AirdropCompleteDocs,
   },
 }

--- a/apps/backend/src/api/embedded-wallets/routes.ts
+++ b/apps/backend/src/api/embedded-wallets/routes.ts
@@ -2,6 +2,8 @@ import { Router } from 'express'
 
 import { authentication } from 'api/core/middlewares/authentication'
 
+import { AirdropComplete, endpoint as AirdropCompleteEndpoint } from './use-cases/airdrop-complete'
+import { AirdropOptions, endpoint as AirdropOptionsEndpoint } from './use-cases/airdrop-options'
 import { CreateWallet, endpoint as CreateWalletEndpoint } from './use-cases/create-wallet'
 import { CreateWalletOptions, endpoint as CreateWalletOptionsEndpoint } from './use-cases/create-wallet-options'
 import { GenerateRecoveryLink, endpoint as GenerateRecoveryLinkEndpoint } from './use-cases/generate-recovery-link'
@@ -37,5 +39,9 @@ router.get(`${TransferOptionsEndpoint}`, authentication, async (req, res) =>
   TransferOptions.init().executeHttp(req, res)
 )
 router.post(`${TransferEndpoint}`, authentication, async (req, res) => Transfer.init().executeHttp(req, res))
+router.get(`${AirdropOptionsEndpoint}`, authentication, async (req, res) => AirdropOptions.init().executeHttp(req, res))
+router.post(`${AirdropCompleteEndpoint}`, authentication, async (req, res) =>
+  AirdropComplete.init().executeHttp(req, res)
+)
 
 export default router

--- a/apps/backend/src/api/embedded-wallets/use-cases/airdrop-complete/index.docs.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/airdrop-complete/index.docs.ts
@@ -1,0 +1,39 @@
+import { badRequest, notFound, unauthorized } from 'api/core/utils/docs/error.docs'
+import { Tags } from 'api/core/utils/docs/tags'
+import { HttpStatusCodes } from 'api/core/utils/http/status-code'
+import { zodToSchema } from 'api/core/utils/zod'
+
+import { RequestSchema, ResponseSchema } from './types'
+
+export default {
+  post: {
+    tags: [Tags.EMBEDDED_WALLETS],
+    summary: 'Complete airdrop claim',
+    description: 'Executes airdrop claim using WebAuthn authentication',
+    responses: {
+      [HttpStatusCodes.OK]: {
+        description: 'Successfully claimed airdrop tokens',
+        content: {
+          'application/json': {
+            schema: zodToSchema(ResponseSchema),
+          },
+        },
+      },
+      ...unauthorized,
+      ...badRequest,
+      ...notFound,
+    },
+    requestBody: {
+      content: {
+        'application/json': {
+          schema: zodToSchema(RequestSchema),
+        },
+      },
+    },
+    security: [
+      {
+        BearerToken: [],
+      },
+    ],
+  },
+}

--- a/apps/backend/src/api/embedded-wallets/use-cases/airdrop-complete/index.test.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/airdrop-complete/index.test.ts
@@ -1,0 +1,397 @@
+import { rpc, Transaction } from '@stellar/stellar-sdk'
+import { Request, Response } from 'express'
+
+import { passkeyFactory } from 'api/core/entities/passkey/factory'
+import { Proof } from 'api/core/entities/proof/model'
+import { userFactory } from 'api/core/entities/user/factory'
+import { submitTx } from 'api/core/helpers/submit-tx'
+import { mockWebAuthnAuthentication } from 'api/core/helpers/webauthn/authentication/mocks'
+import { mockProofRepository } from 'api/core/services/proof/mocks'
+import { mockUserRepository } from 'api/core/services/user/mocks'
+import { HttpStatusCodes } from 'api/core/utils/http/status-code'
+import { STELLAR } from 'config/stellar'
+import { BadRequestException } from 'errors/exceptions/bad-request'
+import { ResourceNotFoundException } from 'errors/exceptions/resource-not-found'
+import { UnauthorizedException } from 'errors/exceptions/unauthorized'
+import { mockSorobanService } from 'interfaces/soroban/mock'
+
+import { AirdropComplete, endpoint } from '.'
+
+vi.mock('api/core/helpers/submit-tx', () => ({
+  submitTx: vi.fn(),
+}))
+
+const mockPasskeys = [
+  passkeyFactory({
+    credentialId: 'cred-1',
+    transports: ['usb', 'nfc'],
+  }),
+  passkeyFactory({
+    credentialId: 'cred-2',
+    transports: ['cable'],
+  }),
+]
+
+const mockUser = userFactory({
+  email: 'test@example.com',
+  contractAddress: 'CCXTP3MIXUFBVEL7Z6MTMW3S325UO2YH5FZMSWUR3QSV5KXVABMTD75D',
+  passkeys: mockPasskeys,
+})
+
+const mockProof: Proof = {
+  receiverAddress: 'CCXTP3MIXUFBVEL7Z6MTMW3S325UO2YH5FZMSWUR3QSV5KXVABMTD75D',
+  contractAddress: STELLAR.AIRDROP_CONTRACT_ADDRESS,
+  index: 123,
+  receiverAmount: '1000000000',
+  proofs: [
+    '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    '9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba',
+  ],
+  createdAt: new Date(),
+}
+
+const mockAuthResponse = JSON.stringify({
+  id: 'credential-id',
+  rawId: 'raw-credential-id',
+  response: {
+    authenticatorData: 'mock-auth-data',
+    clientDataJSON: 'mock-client-data',
+    signature: 'mock-signature',
+  },
+  type: 'public-key',
+})
+
+const mockVerifyAuthResult = {
+  clientDataJSON: 'mock-client-data-json',
+  authenticatorData: 'mock-authenticator-data',
+  compactSignature: 'mock-compact-signature',
+  customMetadata: {
+    type: 'soroban',
+    tx: { hash: 'mock-tx-hash' } as unknown as Transaction,
+    simulationResponse: { id: 'mock-simulation-id' } as unknown as rpc.Api.SimulateTransactionSuccessResponse,
+  },
+}
+
+const mockTxResponse = {
+  status: rpc.Api.GetTransactionStatus.SUCCESS,
+  txHash: 'successful-tx-hash',
+} as unknown as rpc.Api.GetSuccessfulTransactionResponse
+
+const mockedUserRepository = mockUserRepository()
+const mockedProofRepository = mockProofRepository()
+const mockedWebauthnAuthenticationHelper = mockWebAuthnAuthentication()
+const mockedSorobanService = mockSorobanService()
+
+const mockedComplete = vi.fn()
+const mockedSignAuthEntries = vi.fn()
+const mockedSimulateTransaction = vi.fn()
+
+mockedWebauthnAuthenticationHelper.complete = mockedComplete
+mockedSorobanService.signAuthEntries = mockedSignAuthEntries
+mockedSorobanService.simulateTransaction = mockedSimulateTransaction
+
+let useCase: AirdropComplete
+
+describe('AirdropComplete', () => {
+  it('should export endpoint', () => {
+    expect(endpoint).toBe('/airdrop/complete')
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useCase = new AirdropComplete(
+      mockedProofRepository,
+      mockedUserRepository,
+      mockedWebauthnAuthenticationHelper,
+      mockedSorobanService
+    )
+  })
+
+  describe('handle', () => {
+    it('should complete airdrop claim successfully', async () => {
+      const payload = {
+        email: mockUser.email,
+        authentication_response_json: mockAuthResponse,
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(mockProof)
+      mockedComplete.mockResolvedValue(mockVerifyAuthResult)
+
+      const signedTx = { hash: 'signed-tx-hash' } as unknown as Transaction
+      mockedSignAuthEntries.mockResolvedValue(signedTx)
+
+      const simulationResponse = { id: 'final-simulation-id' } as unknown as rpc.Api.SimulateTransactionSuccessResponse
+      mockedSimulateTransaction.mockResolvedValue(simulationResponse)
+
+      vi.mocked(submitTx).mockResolvedValue(mockTxResponse)
+
+      const result = await useCase.handle(payload)
+
+      expect(result).toEqual({
+        data: {
+          hash: mockTxResponse.txHash,
+        },
+        message: 'Airdrop claimed successfully',
+      })
+
+      expect(mockedUserRepository.getUserByEmail).toHaveBeenCalledWith(mockUser.email, { relations: ['passkeys'] })
+
+      expect(mockedProofRepository.findByAddressAndContract).toHaveBeenCalledWith(
+        mockUser.contractAddress,
+        STELLAR.AIRDROP_CONTRACT_ADDRESS
+      )
+
+      expect(mockedComplete).toHaveBeenCalledWith({
+        type: 'raw',
+        user: mockUser,
+        authenticationResponseJSON: mockAuthResponse,
+      })
+
+      expect(mockedSignAuthEntries).toHaveBeenCalledWith({
+        contractId: STELLAR.AIRDROP_CONTRACT_ADDRESS,
+        tx: mockVerifyAuthResult.customMetadata.tx,
+        simulationResponse: mockVerifyAuthResult.customMetadata.simulationResponse,
+        signers: [
+          {
+            addressId: mockUser.contractAddress,
+            methodOptions: {
+              method: 'webauthn',
+              options: {
+                clientDataJSON: mockVerifyAuthResult.clientDataJSON,
+                authenticatorData: mockVerifyAuthResult.authenticatorData,
+                signature: mockVerifyAuthResult.compactSignature,
+              },
+            },
+          },
+        ],
+      })
+
+      expect(mockedSimulateTransaction).toHaveBeenCalledWith(signedTx)
+
+      expect(submitTx).toHaveBeenCalledWith({
+        tx: signedTx,
+        simulationResponse,
+      })
+    })
+
+    it('should throw ZodValidationException when email is not provided', async () => {
+      const payload = {
+        email: '',
+        authentication_response_json: mockAuthResponse,
+      }
+
+      await expect(useCase.handle(payload)).rejects.toThrow('The payload has validation errors')
+    })
+
+    it('should throw ResourceNotFoundException when user is not found', async () => {
+      const payload = {
+        email: 'nonexistent@example.com',
+        authentication_response_json: mockAuthResponse,
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(null)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+
+    it('should throw ResourceNotFoundException when user has no contract address', async () => {
+      const payload = {
+        email: mockUser.email,
+        authentication_response_json: mockAuthResponse,
+      }
+
+      const userWithoutContract = userFactory({
+        email: mockUser.email,
+        contractAddress: '',
+        passkeys: mockUser.passkeys,
+      })
+
+      userWithoutContract.contractAddress = undefined
+      mockedUserRepository.getUserByEmail.mockResolvedValue(userWithoutContract)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+
+    it('should throw ResourceNotFoundException when user has no passkeys', async () => {
+      const payload = {
+        email: mockUser.email,
+        authentication_response_json: mockAuthResponse,
+      }
+
+      const userWithoutPasskeys = userFactory({
+        email: mockUser.email,
+        contractAddress: mockUser.contractAddress,
+        passkeys: [],
+      })
+      mockedUserRepository.getUserByEmail.mockResolvedValue(userWithoutPasskeys)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+
+    it('should throw ResourceNotFoundException when no proof is found', async () => {
+      const payload = {
+        email: mockUser.email,
+        authentication_response_json: mockAuthResponse,
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(null)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+
+    it('should throw ResourceNotFoundException when WebAuthn authentication fails', async () => {
+      const payload = {
+        email: mockUser.email,
+        authentication_response_json: mockAuthResponse,
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(mockProof)
+      mockedComplete.mockResolvedValue(null)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+
+    it('should throw BadRequestException when custom metadata is missing', async () => {
+      const payload = {
+        email: mockUser.email,
+        authentication_response_json: mockAuthResponse,
+      }
+
+      const verifyAuthWithoutMetadata = {
+        ...mockVerifyAuthResult,
+        customMetadata: null,
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(mockProof)
+      mockedComplete.mockResolvedValue(verifyAuthWithoutMetadata)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(BadRequestException)
+    })
+
+    it('should throw BadRequestException when custom metadata type is not soroban', async () => {
+      const payload = {
+        email: mockUser.email,
+        authentication_response_json: mockAuthResponse,
+      }
+
+      const verifyAuthWithWrongMetadata = {
+        ...mockVerifyAuthResult,
+        customMetadata: {
+          type: 'other',
+          tx: mockVerifyAuthResult.customMetadata.tx,
+          simulationResponse: mockVerifyAuthResult.customMetadata.simulationResponse,
+        },
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(mockProof)
+      mockedComplete.mockResolvedValue(verifyAuthWithWrongMetadata)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(BadRequestException)
+    })
+
+    it('should throw ResourceNotFoundException when transaction execution fails', async () => {
+      const payload = {
+        email: mockUser.email,
+        authentication_response_json: mockAuthResponse,
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(mockProof)
+      mockedComplete.mockResolvedValue(mockVerifyAuthResult)
+
+      const signedTx = { hash: 'signed-tx-hash' } as unknown as Transaction
+      mockedSignAuthEntries.mockResolvedValue(signedTx)
+
+      const simulationResponse = { id: 'final-simulation-id' } as unknown as rpc.Api.SimulateTransactionSuccessResponse
+      mockedSimulateTransaction.mockResolvedValue(simulationResponse)
+
+      const failedTxResponse = {
+        status: rpc.Api.GetTransactionStatus.FAILED,
+        txHash: 'failed-tx-hash',
+      } as unknown as rpc.Api.GetSuccessfulTransactionResponse
+      vi.mocked(submitTx).mockResolvedValue(failedTxResponse)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+
+    it('should throw ResourceNotFoundException when transaction response is null', async () => {
+      const payload = {
+        email: mockUser.email,
+        authentication_response_json: mockAuthResponse,
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(mockProof)
+      mockedComplete.mockResolvedValue(mockVerifyAuthResult)
+
+      const signedTx = { hash: 'signed-tx-hash' } as unknown as Transaction
+      mockedSignAuthEntries.mockResolvedValue(signedTx)
+
+      const simulationResponse = { id: 'final-simulation-id' } as unknown as rpc.Api.SimulateTransactionSuccessResponse
+      mockedSimulateTransaction.mockResolvedValue(simulationResponse)
+
+      vi.mocked(submitTx).mockResolvedValue(null as unknown as rpc.Api.GetSuccessfulTransactionResponse)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+  })
+
+  describe('executeHttp', () => {
+    it('should handle HTTP request and return success response', async () => {
+      const mockRequest = {
+        body: {
+          authentication_response_json: mockAuthResponse,
+        },
+        userData: { email: mockUser.email },
+      } as Request
+
+      const mockResponse = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn(),
+      } as unknown as Response
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(mockProof)
+      mockedComplete.mockResolvedValue(mockVerifyAuthResult)
+
+      const signedTx = { hash: 'signed-tx-hash' } as unknown as Transaction
+      mockedSignAuthEntries.mockResolvedValue(signedTx)
+
+      const simulationResponse = { id: 'final-simulation-id' } as unknown as rpc.Api.SimulateTransactionSuccessResponse
+      mockedSimulateTransaction.mockResolvedValue(simulationResponse)
+
+      vi.mocked(submitTx).mockResolvedValue(mockTxResponse)
+
+      await useCase.executeHttp(mockRequest, mockResponse)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCodes.OK)
+      expect(mockResponse.json).toHaveBeenCalledWith({
+        data: {
+          hash: mockTxResponse.txHash,
+        },
+        message: 'Airdrop claimed successfully',
+      })
+    })
+
+    it('should throw UnauthorizedException when no user data in request', async () => {
+      const mockRequest = {
+        body: {
+          authentication_response_json: mockAuthResponse,
+        },
+        userData: undefined,
+      } as Request
+
+      const mockResponse = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn(),
+      } as unknown as Response
+
+      await expect(useCase.executeHttp(mockRequest, mockResponse)).rejects.toThrow(UnauthorizedException)
+    })
+  })
+})

--- a/apps/backend/src/api/embedded-wallets/use-cases/airdrop-complete/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/airdrop-complete/index.ts
@@ -1,0 +1,146 @@
+import { rpc } from '@stellar/stellar-sdk'
+import { Request, Response } from 'express'
+
+import { ProofRepositoryType } from 'api/core/entities/proof/types'
+import { UserRepositoryType } from 'api/core/entities/user/types'
+import { UseCaseBase } from 'api/core/framework/use-case/base'
+import { IUseCaseHttp } from 'api/core/framework/use-case/http'
+import { submitTx } from 'api/core/helpers/submit-tx'
+import WebAuthnAuthentication from 'api/core/helpers/webauthn/authentication'
+import { IWebAuthnAuthentication } from 'api/core/helpers/webauthn/authentication/types'
+import ProofRepository from 'api/core/services/proof'
+import UserRepository from 'api/core/services/user'
+import { HttpStatusCodes } from 'api/core/utils/http/status-code'
+import { messages } from 'api/embedded-wallets/constants/messages'
+import { STELLAR } from 'config/stellar'
+import { BadRequestException } from 'errors/exceptions/bad-request'
+import { ResourceNotFoundException } from 'errors/exceptions/resource-not-found'
+import { UnauthorizedException } from 'errors/exceptions/unauthorized'
+import SorobanService from 'interfaces/soroban'
+import { ISorobanService, ContractSigner } from 'interfaces/soroban/types'
+
+import { RequestSchema, RequestSchemaT, ResponseSchemaT } from './types'
+
+const endpoint = '/airdrop/complete'
+
+export class AirdropComplete extends UseCaseBase implements IUseCaseHttp<ResponseSchemaT> {
+  private proofRepository: ProofRepositoryType
+  private userRepository: UserRepositoryType
+  private webauthnAuthenticationHelper: IWebAuthnAuthentication
+  private sorobanService: ISorobanService
+
+  constructor(
+    proofRepository?: ProofRepositoryType,
+    userRepository?: UserRepositoryType,
+    webauthnAuthenticationHelper?: IWebAuthnAuthentication,
+    sorobanService?: ISorobanService
+  ) {
+    super()
+    this.proofRepository = proofRepository || ProofRepository.getInstance()
+    this.userRepository = userRepository || UserRepository.getInstance()
+    this.webauthnAuthenticationHelper = webauthnAuthenticationHelper || WebAuthnAuthentication.getInstance()
+    this.sorobanService = sorobanService || SorobanService.getInstance()
+  }
+
+  async executeHttp(request: Request, response: Response<ResponseSchemaT>) {
+    const payload = {
+      ...request.body,
+      email: request.userData?.email,
+    } as RequestSchemaT
+
+    if (!payload.email) {
+      throw new UnauthorizedException(messages.NOT_AUTHORIZED)
+    }
+
+    const result = await this.handle(payload)
+    return response.status(HttpStatusCodes.OK).json(result)
+  }
+
+  async handle(payload: RequestSchemaT): Promise<ResponseSchemaT> {
+    const validatedData = this.validate(payload, RequestSchema)
+
+    // Get user data
+    const { email } = validatedData
+
+    const user = await this.userRepository.getUserByEmail(email, { relations: ['passkeys'] })
+
+    if (!user) {
+      throw new ResourceNotFoundException(messages.USER_NOT_FOUND_BY_EMAIL)
+    }
+
+    if (!user.contractAddress) {
+      throw new ResourceNotFoundException(messages.USER_DOES_NOT_HAVE_WALLET)
+    }
+
+    if (!user.passkeys.length) {
+      throw new ResourceNotFoundException(messages.USER_DOES_NOT_HAVE_PASSKEYS)
+    }
+
+    // Get airdrop contract address from config
+    const airdropContractAddress = STELLAR.AIRDROP_CONTRACT_ADDRESS
+
+    // Verify user has a proof for this airdrop
+    const proof = await this.proofRepository.findByAddressAndContract(user.contractAddress, airdropContractAddress)
+
+    if (!proof) {
+      throw new ResourceNotFoundException(messages.AIRDROP_PROOF_NOT_FOUND)
+    }
+
+    // Verify auth/challenge
+    const verifyAuth = await this.webauthnAuthenticationHelper.complete({
+      type: 'raw',
+      user,
+      authenticationResponseJSON: validatedData.authentication_response_json,
+    })
+
+    if (!verifyAuth) {
+      throw new ResourceNotFoundException(messages.UNABLE_TO_COMPLETE_PASSKEY_AUTHENTICATION)
+    }
+
+    const { customMetadata } = verifyAuth
+
+    if (!customMetadata || customMetadata.type !== 'soroban') {
+      throw new BadRequestException(messages.UNABLE_TO_FIND_SOROBAN_CUSTOM_METADATA)
+    }
+
+    // Build contract signer
+    const passkeySigner: ContractSigner = {
+      addressId: user.contractAddress as string,
+      methodOptions: {
+        method: 'webauthn',
+        options: {
+          clientDataJSON: verifyAuth.clientDataJSON,
+          authenticatorData: verifyAuth.authenticatorData,
+          signature: verifyAuth.compactSignature,
+        },
+      },
+    }
+
+    // Sign auth entries
+    const tx = await this.sorobanService.signAuthEntries({
+      contractId: airdropContractAddress,
+      tx: customMetadata.tx,
+      simulationResponse: customMetadata.simulationResponse,
+      signers: [passkeySigner],
+    })
+
+    // Simulate claim transaction
+    const simulationResponse = await this.sorobanService.simulateTransaction(tx)
+
+    // Broadcast claim transaction
+    const txResponse = await submitTx({ tx, simulationResponse })
+
+    if (!txResponse || txResponse.status !== rpc.Api.GetTransactionStatus.SUCCESS) {
+      throw new ResourceNotFoundException(messages.UNABLE_TO_EXECUTE_AIRDROP_CLAIM)
+    }
+
+    return {
+      data: {
+        hash: txResponse.txHash,
+      },
+      message: 'Airdrop claimed successfully',
+    }
+  }
+}
+
+export { endpoint }

--- a/apps/backend/src/api/embedded-wallets/use-cases/airdrop-complete/types.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/airdrop-complete/types.ts
@@ -1,0 +1,19 @@
+import { z } from 'zod'
+
+import { createResponseSchema } from 'api/core/framework/use-case/base'
+import { refineJsonString } from 'api/core/utils/zod'
+
+export const RequestSchema = z.object({
+  email: z.string().email(),
+  authentication_response_json: z.string().refine(refineJsonString),
+})
+
+export type RequestSchemaT = z.infer<typeof RequestSchema>
+
+export const ResponseSchema = createResponseSchema(
+  z.object({
+    hash: z.string(),
+  })
+)
+
+export type ResponseSchemaT = z.infer<typeof ResponseSchema>

--- a/apps/backend/src/api/embedded-wallets/use-cases/airdrop-options/index.docs.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/airdrop-options/index.docs.ts
@@ -1,0 +1,32 @@
+import { badRequest, notFound, unauthorized } from 'api/core/utils/docs/error.docs'
+import { Tags } from 'api/core/utils/docs/tags'
+import { HttpStatusCodes } from 'api/core/utils/http/status-code'
+import { zodToSchema } from 'api/core/utils/zod'
+
+import { ResponseSchema } from './types'
+
+export default {
+  get: {
+    tags: [Tags.EMBEDDED_WALLETS],
+    summary: 'Get airdrop claim options',
+    description: 'Validates eligibility and generates WebAuthn challenge for airdrop claim',
+    responses: {
+      [HttpStatusCodes.OK]: {
+        description: 'Successfully retrieved airdrop claim options with WebAuthn challenge',
+        content: {
+          'application/json': {
+            schema: zodToSchema(ResponseSchema),
+          },
+        },
+      },
+      ...unauthorized,
+      ...badRequest,
+      ...notFound,
+    },
+    security: [
+      {
+        BearerToken: [],
+      },
+    ],
+  },
+}

--- a/apps/backend/src/api/embedded-wallets/use-cases/airdrop-options/index.test.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/airdrop-options/index.test.ts
@@ -1,0 +1,297 @@
+import { nativeToScVal, rpc, Transaction } from '@stellar/stellar-sdk'
+import { Request, Response } from 'express'
+
+import { passkeyFactory } from 'api/core/entities/passkey/factory'
+import { Proof } from 'api/core/entities/proof/model'
+import { userFactory } from 'api/core/entities/user/factory'
+import { mockWebAuthnAuthentication } from 'api/core/helpers/webauthn/authentication/mocks'
+import { mockProofRepository } from 'api/core/services/proof/mocks'
+import { mockUserRepository } from 'api/core/services/user/mocks'
+import { HttpStatusCodes } from 'api/core/utils/http/status-code'
+import { STELLAR } from 'config/stellar'
+import { ResourceNotFoundException } from 'errors/exceptions/resource-not-found'
+import { UnauthorizedException } from 'errors/exceptions/unauthorized'
+import { mockSorobanService } from 'interfaces/soroban/mock'
+
+import { AirdropOptions, endpoint } from '.'
+
+const mockPasskeys = [
+  passkeyFactory({
+    credentialId: 'cred-1',
+    transports: ['usb', 'nfc'],
+  }),
+  passkeyFactory({
+    credentialId: 'cred-2',
+    transports: ['cable'],
+  }),
+]
+
+const mockUser = userFactory({
+  email: 'test@example.com',
+  contractAddress: 'CCXTP3MIXUFBVEL7Z6MTMW3S325UO2YH5FZMSWUR3QSV5KXVABMTD75D',
+  passkeys: mockPasskeys,
+})
+
+const mockProof: Proof = {
+  receiverAddress: 'CCXTP3MIXUFBVEL7Z6MTMW3S325UO2YH5FZMSWUR3QSV5KXVABMTD75D',
+  contractAddress: STELLAR.AIRDROP_CONTRACT_ADDRESS,
+  index: 123,
+  receiverAmount: '1000000000',
+  proofs: [
+    '1234567890abcdef1234567890abcdef1234567890abcdef1234567890abcdef',
+    '9876543210fedcba9876543210fedcba9876543210fedcba9876543210fedcba',
+  ],
+  createdAt: new Date(),
+}
+
+const mockChallenge = 'mock-challenge-data'
+const mockOptions = '{"challenge":"mock-challenge","userVerification":"required"}'
+
+const mockedUserRepository = mockUserRepository()
+const mockedProofRepository = mockProofRepository()
+const mockedWebauthnAuthenticationHelper = mockWebAuthnAuthentication()
+const mockedSorobanService = mockSorobanService()
+
+const mockedGenerateOptions = vi.fn()
+const mockedGenerateWebAuthnChallenge = vi.fn()
+
+mockedWebauthnAuthenticationHelper.generateOptions = mockedGenerateOptions
+mockedSorobanService.generateWebAuthnChallenge = mockedGenerateWebAuthnChallenge
+
+let useCase: AirdropOptions
+
+describe('AirdropOptions', () => {
+  it('should export endpoint', () => {
+    expect(endpoint).toBe('/airdrop/options')
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useCase = new AirdropOptions(
+      mockedProofRepository,
+      mockedUserRepository,
+      mockedWebauthnAuthenticationHelper,
+      mockedSorobanService
+    )
+
+    mockedSorobanService.simulateContractOperation
+      .mockResolvedValueOnce({
+        tx: { hash: 'test-tx-hash' } as unknown as Transaction,
+        simulationResponse: {
+          id: 'simulation-id',
+          result: {
+            retval: nativeToScVal(false, { type: 'bool' }),
+          },
+        } as unknown as rpc.Api.SimulateTransactionSuccessResponse,
+      })
+      .mockResolvedValueOnce({
+        tx: { hash: 'claim-tx-hash' } as unknown as Transaction,
+        simulationResponse: { id: 'claim-simulation-id' } as unknown as rpc.Api.SimulateTransactionSuccessResponse,
+      })
+  })
+
+  describe('handle', () => {
+    it('should return airdrop claim options successfully', async () => {
+      const payload = {
+        email: mockUser.email,
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(mockProof)
+      mockedGenerateWebAuthnChallenge.mockResolvedValue(mockChallenge)
+      mockedGenerateOptions.mockResolvedValue(mockOptions)
+
+      const result = await useCase.handle(payload)
+
+      expect(result.data.options_json).toBe(mockOptions)
+      expect(result.data.user.email).toBe(mockUser.email)
+      expect(result.data.user.address).toBe(mockUser.contractAddress)
+      expect(result.message).toBe('Retrieved airdrop claim options successfully')
+
+      expect(mockedProofRepository.findByAddressAndContract).toHaveBeenCalledWith(
+        mockUser.contractAddress,
+        STELLAR.AIRDROP_CONTRACT_ADDRESS
+      )
+
+      expect(mockedSorobanService.simulateContractOperation).toHaveBeenNthCalledWith(1, {
+        contractId: STELLAR.AIRDROP_CONTRACT_ADDRESS,
+        method: 'is_claimed',
+        args: [nativeToScVal(mockProof.index, { type: 'u32' })],
+      })
+
+      expect(mockedSorobanService.simulateContractOperation).toHaveBeenNthCalledWith(2, {
+        contractId: STELLAR.AIRDROP_CONTRACT_ADDRESS,
+        method: 'claim',
+        args: expect.arrayContaining([
+          nativeToScVal(mockProof.index, { type: 'u32' }),
+          expect.any(Object),
+          expect.any(Object),
+          expect.any(Object),
+        ]),
+      })
+
+      expect(mockedGenerateWebAuthnChallenge).toHaveBeenCalledWith({
+        contractId: STELLAR.AIRDROP_CONTRACT_ADDRESS,
+        simulationResponse: expect.any(Object),
+        signer: {
+          addressId: mockUser.contractAddress,
+        },
+      })
+
+      expect(mockedGenerateOptions).toHaveBeenCalledWith({
+        type: 'raw',
+        user: mockUser,
+        customChallenge: mockChallenge,
+        customMetadata: {
+          type: 'soroban',
+          tx: expect.any(Object),
+          simulationResponse: expect.any(Object),
+        },
+      })
+    })
+
+    it('should throw ZodValidationException when email is not provided', async () => {
+      const payload = {
+        email: '',
+      }
+
+      await expect(useCase.handle(payload)).rejects.toThrow('The payload has validation errors')
+    })
+
+    it('should throw ResourceNotFoundException when user is not found', async () => {
+      const payload = {
+        email: 'nonexistent@example.com',
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(null)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+
+    it('should throw ResourceNotFoundException when user has no contract address', async () => {
+      const payload = {
+        email: mockUser.email,
+      }
+
+      const userWithoutContract = userFactory({
+        email: mockUser.email,
+        contractAddress: '',
+        passkeys: mockUser.passkeys,
+      })
+
+      userWithoutContract.contractAddress = undefined
+      mockedUserRepository.getUserByEmail.mockResolvedValue(userWithoutContract)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+
+    it('should throw ResourceNotFoundException when user has no passkeys', async () => {
+      const payload = {
+        email: mockUser.email,
+      }
+
+      const userWithoutPasskeys = userFactory({
+        email: mockUser.email,
+        contractAddress: mockUser.contractAddress,
+        passkeys: [],
+      })
+      mockedUserRepository.getUserByEmail.mockResolvedValue(userWithoutPasskeys)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+
+    it('should throw ResourceNotFoundException when no proof is found', async () => {
+      const payload = {
+        email: mockUser.email,
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(null)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+
+    it('should throw ResourceNotFoundException when airdrop is already claimed', async () => {
+      const payload = {
+        email: mockUser.email,
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(mockProof)
+
+      mockedSorobanService.simulateContractOperation.mockReset()
+      mockedSorobanService.simulateContractOperation.mockResolvedValueOnce({
+        tx: { hash: 'test-tx-hash' } as unknown as Transaction,
+        simulationResponse: {
+          id: 'simulation-id',
+          result: {
+            retval: nativeToScVal(true, { type: 'bool' }),
+          },
+        } as unknown as rpc.Api.SimulateTransactionSuccessResponse,
+      })
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+
+    it('should throw ResourceNotFoundException when WebAuthn options generation fails', async () => {
+      const payload = {
+        email: mockUser.email,
+      }
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(mockProof)
+      mockedGenerateWebAuthnChallenge.mockResolvedValue(mockChallenge)
+      mockedGenerateOptions.mockResolvedValue(null)
+
+      await expect(useCase.handle(payload)).rejects.toThrow(ResourceNotFoundException)
+    })
+  })
+
+  describe('executeHttp', () => {
+    it('should handle HTTP request and return success response', async () => {
+      const mockRequest = {
+        query: {},
+        userData: { email: mockUser.email },
+      } as unknown as Request
+
+      const mockResponse = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn(),
+      } as unknown as Response
+
+      mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
+      mockedProofRepository.findByAddressAndContract.mockResolvedValue(mockProof)
+      mockedGenerateWebAuthnChallenge.mockResolvedValue(mockChallenge)
+      mockedGenerateOptions.mockResolvedValue(mockOptions)
+
+      await useCase.executeHttp(mockRequest, mockResponse)
+
+      expect(mockResponse.status).toHaveBeenCalledWith(HttpStatusCodes.OK)
+      expect(mockResponse.json).toHaveBeenCalledWith(
+        expect.objectContaining({
+          data: expect.objectContaining({
+            options_json: mockOptions,
+            user: expect.objectContaining({
+              email: mockUser.email,
+              address: mockUser.contractAddress,
+            }),
+          }),
+        })
+      )
+    })
+
+    it('should throw UnauthorizedException when no user data in request', async () => {
+      const mockRequest = {
+        query: {},
+        userData: undefined,
+      } as unknown as Request
+
+      const mockResponse = {
+        status: vi.fn().mockReturnThis(),
+        json: vi.fn(),
+      } as unknown as Response
+
+      await expect(useCase.executeHttp(mockRequest, mockResponse)).rejects.toThrow(UnauthorizedException)
+    })
+  })
+})

--- a/apps/backend/src/api/embedded-wallets/use-cases/airdrop-options/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/airdrop-options/index.ts
@@ -1,0 +1,160 @@
+import { nativeToScVal, xdr } from '@stellar/stellar-sdk'
+import { Request, Response } from 'express'
+
+import { ProofRepositoryType } from 'api/core/entities/proof/types'
+import { UserRepositoryType } from 'api/core/entities/user/types'
+import { UseCaseBase } from 'api/core/framework/use-case/base'
+import { IUseCaseHttp } from 'api/core/framework/use-case/http'
+import WebAuthnAuthentication from 'api/core/helpers/webauthn/authentication'
+import { IWebAuthnAuthentication } from 'api/core/helpers/webauthn/authentication/types'
+import ProofRepository from 'api/core/services/proof'
+import UserRepository from 'api/core/services/user'
+import { HttpStatusCodes } from 'api/core/utils/http/status-code'
+import { messages } from 'api/embedded-wallets/constants/messages'
+import { STELLAR } from 'config/stellar'
+import { ResourceNotFoundException } from 'errors/exceptions/resource-not-found'
+import { UnauthorizedException } from 'errors/exceptions/unauthorized'
+import SorobanService from 'interfaces/soroban'
+import { ISorobanService } from 'interfaces/soroban/types'
+
+import { RequestSchema, RequestSchemaT, ResponseSchemaT } from './types'
+
+const endpoint = '/airdrop/options'
+
+export class AirdropOptions extends UseCaseBase implements IUseCaseHttp<ResponseSchemaT> {
+  private proofRepository: ProofRepositoryType
+  private userRepository: UserRepositoryType
+  private webauthnAuthenticationHelper: IWebAuthnAuthentication
+  private sorobanService: ISorobanService
+
+  constructor(
+    proofRepository?: ProofRepositoryType,
+    userRepository?: UserRepositoryType,
+    webauthnAuthenticationHelper?: IWebAuthnAuthentication,
+    sorobanService?: ISorobanService
+  ) {
+    super()
+    this.proofRepository = proofRepository || ProofRepository.getInstance()
+    this.userRepository = userRepository || UserRepository.getInstance()
+    this.webauthnAuthenticationHelper = webauthnAuthenticationHelper || WebAuthnAuthentication.getInstance()
+    this.sorobanService = sorobanService || SorobanService.getInstance()
+  }
+
+  async executeHttp(request: Request, response: Response<ResponseSchemaT>) {
+    const payload = {
+      ...request.query,
+      email: request.userData?.email,
+    } as RequestSchemaT
+
+    if (!payload.email) {
+      throw new UnauthorizedException(messages.NOT_AUTHORIZED)
+    }
+
+    const result = await this.handle(payload)
+    return response.status(HttpStatusCodes.OK).json(result)
+  }
+
+  async handle(payload: RequestSchemaT): Promise<ResponseSchemaT> {
+    const validatedData = this.validate(payload, RequestSchema)
+
+    // Get user data
+    const { email } = validatedData
+
+    const user = await this.userRepository.getUserByEmail(email, { relations: ['passkeys'] })
+    if (!user) {
+      throw new ResourceNotFoundException(messages.USER_NOT_FOUND_BY_EMAIL)
+    }
+
+    if (!user.contractAddress) {
+      throw new ResourceNotFoundException(messages.USER_DOES_NOT_HAVE_WALLET)
+    }
+
+    if (!user.passkeys.length) {
+      throw new ResourceNotFoundException(messages.USER_DOES_NOT_HAVE_PASSKEYS)
+    }
+
+    // Get airdrop contract address from config
+    const airdropContractAddress = STELLAR.AIRDROP_CONTRACT_ADDRESS
+
+    // Get user's Merkle proof from database
+    const proof = await this.proofRepository.findByAddressAndContract(user.contractAddress, airdropContractAddress)
+
+    if (!proof) {
+      throw new ResourceNotFoundException(messages.AIRDROP_PROOF_NOT_FOUND)
+    }
+
+    // Check if claim has already been made
+    const isClaimedResult = await this.sorobanService.simulateContractOperation({
+      contractId: airdropContractAddress,
+      method: 'is_claimed',
+      args: [nativeToScVal(proof.index, { type: 'u32' })],
+    })
+
+    // If the claim simulation succeeds and returns true, the claim has already been made
+    if (isClaimedResult.simulationResponse.result?.retval) {
+      const isClaimedValue = isClaimedResult.simulationResponse.result.retval
+      if (isClaimedValue.switch().name === 'scvBool' && isClaimedValue.b()) {
+        throw new ResourceNotFoundException(messages.AIRDROP_ALREADY_CLAIMED)
+      }
+    }
+
+    // Convert proof hex strings to ScVals
+    const proofScVals = proof.proofs.map((proofHex: string) => {
+      const proofBytes = Uint8Array.from(Buffer.from(proofHex, 'hex'))
+      return nativeToScVal(proofBytes, { type: 'bytes' })
+    })
+
+    // Set claim transaction parameters
+    const args: xdr.ScVal[] = [
+      nativeToScVal(proof.index, { type: 'u32' }), // index
+      nativeToScVal(user.contractAddress as string, { type: 'address' }), // receiver
+      nativeToScVal(proof.receiverAmount, { type: 'i128' }), // amount
+      nativeToScVal(proofScVals, { type: 'vec' }), // proof vector
+    ]
+
+    // Simulate claim contract operation
+    const { tx, simulationResponse } = await this.sorobanService.simulateContractOperation({
+      contractId: airdropContractAddress,
+      method: 'claim',
+      args,
+    })
+
+    // Generate challenge
+    const challenge = await this.sorobanService.generateWebAuthnChallenge({
+      contractId: airdropContractAddress,
+      simulationResponse: simulationResponse,
+      signer: {
+        addressId: user.contractAddress as string,
+      },
+    })
+
+    // Generate options based on custom challenge (tx simulation)
+    const options = await this.webauthnAuthenticationHelper.generateOptions({
+      type: 'raw',
+      user: user,
+      customChallenge: challenge,
+      customMetadata: {
+        type: 'soroban',
+        tx: tx,
+        simulationResponse: simulationResponse,
+      },
+    })
+
+    if (!options) {
+      throw new ResourceNotFoundException(messages.UNABLE_TO_COMPLETE_PASSKEY_AUTHENTICATION)
+    }
+
+    return {
+      data: {
+        options_json: options,
+        user: {
+          email: user.email,
+          address: user.contractAddress,
+        },
+      },
+      message: 'Retrieved airdrop claim options successfully',
+    }
+  }
+}
+
+export { endpoint }

--- a/apps/backend/src/api/embedded-wallets/use-cases/airdrop-options/types.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/airdrop-options/types.ts
@@ -1,0 +1,22 @@
+import { z } from 'zod'
+
+import { createResponseSchema } from 'api/core/framework/use-case/base'
+import { refineJsonString } from 'api/core/utils/zod'
+
+export const RequestSchema = z.object({
+  email: z.string().email(),
+})
+
+export type RequestSchemaT = z.infer<typeof RequestSchema>
+
+export const ResponseSchema = createResponseSchema(
+  z.object({
+    options_json: z.string().refine(refineJsonString),
+    user: z.object({
+      address: z.string(),
+      email: z.string().email(),
+    }),
+  })
+)
+
+export type ResponseSchemaT = z.infer<typeof ResponseSchema>


### PR DESCRIPTION
### What

This implements new airdrop APIs that follow the transfer API flow. The deprecated proofs endpoint will be removed in a separate PR.

### Why

The other APIs construct the challenge on the backend, and the frontend is only responsible for signing the challenge.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
