### PR TITLE
Refactor: lock wallet creation with loading while in hold statuses

### DIFF
--- a/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.ts
@@ -118,7 +118,7 @@ export class GetWallet extends UseCaseBase implements IUseCaseHttp<ResponseSchem
         break
       }
       // If the address is not yet available, wait for a while before checking again
-      await sleepInSeconds(1)
+      await sleepInSeconds(2)
     }
 
     if (!user.contractAddress)

--- a/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.ts
@@ -18,7 +18,6 @@ import { HttpStatusCodes } from 'api/core/utils/http/status-code'
 import { sleepInSeconds } from 'api/core/utils/sleep'
 import { messages } from 'api/embedded-wallets/constants/messages'
 import { STELLAR } from 'config/stellar'
-import { BadRequestException } from 'errors/exceptions/bad-request'
 import { ResourceNotFoundException } from 'errors/exceptions/resource-not-found'
 import { UnauthorizedException } from 'errors/exceptions/unauthorized'
 import SDPEmbeddedWallets from 'interfaces/sdp-embedded-wallets'
@@ -122,9 +121,14 @@ export class GetWallet extends UseCaseBase implements IUseCaseHttp<ResponseSchem
       await sleepInSeconds(1)
     }
 
-    if (!user.contractAddress) {
-      throw new BadRequestException(messages.UNKNOWN_CONTRACT_ADDRESS_CREATION_ERROR)
-    }
+    if (!user.contractAddress)
+      return this.parseResponse({
+        status: walletStatus,
+        address: 'unknown',
+        balance: 0,
+        email: user.email,
+        is_airdrop_available: false,
+      })
 
     // Get all info from a valid wallet (balance, etc)
     const { balance, isAirdropAvailable, swags } = await this.infoFromValidWallet(user.userId, user.contractAddress)

--- a/apps/web/src/app/auth/constants/storage.ts
+++ b/apps/web/src/app/auth/constants/storage.ts
@@ -5,4 +5,5 @@ export const AUTH_TOKEN_CHANNEL_KEY = `${APP_NAME}/broadcast-channel/auth-token`
 export const ACCESS_TOKEN_STORAGE_KEY = `${APP_NAME}/access-token`
 export const EMAIL_STORAGE_KEY = `${APP_NAME}/email`
 export const WALLET_ADDRESS_STORAGE_KEY = `${APP_NAME}/wallet-address`
+export const WALLET_STATUS_STORAGE_KEY = `${APP_NAME}/wallet-status`
 export const AIRDROP_STORAGE_KEY = `${APP_NAME}/airdrop`

--- a/apps/web/src/app/wallet/domain/use-cases/get-wallet/index.ts
+++ b/apps/web/src/app/wallet/domain/use-cases/get-wallet/index.ts
@@ -2,6 +2,7 @@ import { UseCaseBase } from 'src/app/core/framework/use-case/base'
 import { walletService } from 'src/app/wallet/services'
 import { IWalletService } from 'src/app/wallet/services/wallet/types'
 import { useWalletAddressStore } from 'src/app/wallet/store'
+import { useWalletStatusStore } from 'src/app/wallet/store/wallet-status'
 
 import { GetWalletResult } from './types'
 
@@ -17,6 +18,7 @@ export class GetWalletUseCase extends UseCaseBase<GetWalletResult> {
     const { data } = await this.walletService.getWallet()
 
     useWalletAddressStore.getState().setWalletAddress(data.address)
+    useWalletStatusStore.getState().setWalletStatus(data.status)
 
     return data
   }

--- a/apps/web/src/app/wallet/pages/profile/index.tsx
+++ b/apps/web/src/app/wallet/pages/profile/index.tsx
@@ -8,12 +8,14 @@ import { ProfileTemplate } from './template'
 import { useGetWallet } from '../../queries/use-get-wallet'
 import { WalletPagesPath } from '../../routes/types'
 import { useWalletAddressStore } from '../../store'
+import { useWalletStatusStore } from '../../store/wallet-status'
 
 export const Profile = () => {
   const navigate = useNavigate()
   const { clearAccessToken } = useAccessTokenStore()
   const { clearEmail } = useEmailStore()
   const { clearWalletAddress } = useWalletAddressStore()
+  const { clearWalletStatus } = useWalletStatusStore()
   const canGoBack = useCanGoBack()
   const router = useRouter()
 
@@ -38,6 +40,7 @@ export const Profile = () => {
     clearAccessToken(AuthPagesPath.WELCOME)
     clearEmail()
     clearWalletAddress()
+    clearWalletStatus()
   }
 
   return (

--- a/apps/web/src/app/wallet/routes/components/index.ts
+++ b/apps/web/src/app/wallet/routes/components/index.ts
@@ -1,0 +1,2 @@
+export * from './wallet-route-error'
+export * from './wallet-route-loading'

--- a/apps/web/src/app/wallet/routes/components/wallet-route-error/index.tsx
+++ b/apps/web/src/app/wallet/routes/components/wallet-route-error/index.tsx
@@ -1,0 +1,34 @@
+import { Icon, Text } from '@stellar/design-system'
+import { useMemo } from 'react'
+
+import { useWalletStatusStore } from 'src/app/wallet/store/wallet-status'
+import { c } from 'src/interfaces/cms/useContent'
+
+export const WalletRouteError = () => {
+  const { status: walletStatus } = useWalletStatusStore()
+
+  const description = useMemo(() => {
+    switch (walletStatus) {
+      case 'FAILED':
+        return c('walletStatusError')
+      default:
+        return c('defaultWalletRouteErrorDescription')
+    }
+  }, [walletStatus])
+
+  return (
+    <div className="flex justify-center items-center h-screen">
+      <div className="flex flex-col items-center gap-6 px-11">
+        {/* Error Indicator */}
+        <div className="text-danger">
+          <Icon.XCircle width={'10vh'} height={'10vh'} />
+        </div>
+
+        {/* Description */}
+        <Text as="span" size="md" weight="medium" addlClassName="text-center">
+          {description}
+        </Text>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/wallet/routes/components/wallet-route-loading/index.tsx
+++ b/apps/web/src/app/wallet/routes/components/wallet-route-loading/index.tsx
@@ -1,0 +1,46 @@
+import { Text } from '@stellar/design-system'
+import { useEffect, useMemo, useState } from 'react'
+
+import { useWalletStatusStore } from 'src/app/wallet/store/wallet-status'
+import { Loading } from 'src/components/atoms'
+import { c } from 'src/interfaces/cms/useContent'
+
+export const WalletRouteLoading = () => {
+  const { status: walletStatus } = useWalletStatusStore()
+  const [timeoutReached, setTimeoutReached] = useState(false)
+
+  // Trigger timeout after 30 seconds
+  useEffect(() => {
+    const timer = setTimeout(() => setTimeoutReached(true), 30000)
+    return () => clearTimeout(timer)
+  }, [])
+
+  const description = useMemo(() => {
+    if (timeoutReached) {
+      return c('stuckWalletRouteLoadingDescription')
+    }
+
+    switch (walletStatus) {
+      case 'PENDING':
+        return c('walletStatusPending')
+      case 'PROCESSING':
+        return c('walletStatusProcessing')
+      default:
+        return c('defaultWalletRouteLoadingDescription')
+    }
+  }, [timeoutReached, walletStatus])
+
+  return (
+    <div className="flex justify-center items-center h-screen">
+      <div className="flex flex-col gap-6 px-11">
+        {/* Loading Indicator */}
+        <Loading />
+
+        {/* Description */}
+        <Text as="span" size="md" weight="medium" addlClassName="text-center">
+          {description}
+        </Text>
+      </div>
+    </div>
+  )
+}

--- a/apps/web/src/app/wallet/store/wallet-address/index.ts
+++ b/apps/web/src/app/wallet/store/wallet-address/index.ts
@@ -1,7 +1,7 @@
 import { create } from 'zustand'
 import { createJSONStorage, persist } from 'zustand/middleware'
 
-import { EMAIL_STORAGE_KEY } from 'src/app/auth/constants/storage'
+import { WALLET_ADDRESS_STORAGE_KEY } from 'src/app/auth/constants/storage'
 
 import { WalletAddressStoreFields, WalletAddressStoreState } from './types'
 
@@ -17,7 +17,7 @@ export const useWalletAddressStore = create<WalletAddressStoreState>()(
       clearWalletAddress: () => set({ address: null }),
     }),
     {
-      name: EMAIL_STORAGE_KEY,
+      name: WALLET_ADDRESS_STORAGE_KEY,
       storage: createJSONStorage(() => localStorage),
     }
   )

--- a/apps/web/src/app/wallet/store/wallet-status/index.ts
+++ b/apps/web/src/app/wallet/store/wallet-status/index.ts
@@ -1,0 +1,24 @@
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+
+import { WALLET_STATUS_STORAGE_KEY } from 'src/app/auth/constants/storage'
+
+import { WalletStatusStoreFields, WalletStatusStoreState } from './types'
+
+const INITIAL_STATE: WalletStatusStoreFields = {
+  status: null,
+}
+
+export const useWalletStatusStore = create<WalletStatusStoreState>()(
+  persist(
+    set => ({
+      ...INITIAL_STATE,
+      setWalletStatus: status => set({ status }),
+      clearWalletStatus: () => set({ status: null }),
+    }),
+    {
+      name: WALLET_STATUS_STORAGE_KEY,
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+)

--- a/apps/web/src/app/wallet/store/wallet-status/types.ts
+++ b/apps/web/src/app/wallet/store/wallet-status/types.ts
@@ -1,0 +1,12 @@
+import { WalletStatus } from 'src/app/auth/domain/models/user'
+
+export type WalletStatusStoreFields = {
+  status: WalletStatus | null
+}
+
+export type WalletStatusStoreActions = {
+  setWalletStatus: (status: WalletStatus | null) => void
+  clearWalletStatus: () => void
+}
+
+export type WalletStatusStoreState = WalletStatusStoreFields & WalletStatusStoreActions

--- a/apps/web/src/app/wallet/store/wallet-status/wallet-status.store.test.ts
+++ b/apps/web/src/app/wallet/store/wallet-status/wallet-status.store.test.ts
@@ -1,0 +1,11 @@
+import { renderHook } from '@testing-library/react'
+
+import { useWalletStatusStore } from '../wallet-status'
+
+describe('EmailStore', () => {
+  it('creates an wallet-status store with initial state empty', () => {
+    const store = renderHook(() => useWalletStatusStore()).result.current
+
+    expect(store.status).toBeNull()
+  })
+})

--- a/apps/web/src/config/content.example.json
+++ b/apps/web/src/config/content.example.json
@@ -91,5 +91,11 @@
   "webauthnInvalidStateError": "This action cannot be completed right now. Please refresh the page or try again",
   "webauthnNotAllowedError": "The operation either cancelled, timed out, or was not allowed",
   "webauthnSecurityError": "This action is blocked for security reasons. Make sure you are using a secure connection and the correct site",
-  "webauthnConstraintError": "Some required information is missing or not valid. Please check your input and try again"
+  "webauthnConstraintError": "Some required information is missing or not valid. Please check your input and try again",
+  "defaultWalletRouteLoadingDescription": "Loading… please wait a moment.",
+  "stuckWalletRouteLoadingDescription": "We're having trouble right now. Please try again later.",
+  "defaultWalletRouteErrorDescription": "We're experiencing an issue right now. Please try again later.",
+  "walletStatusPending": "Your wallet setup is pending. Hang tight, we'll start soon.",
+  "walletStatusProcessing": "We're working on setting up your wallet right now.",
+  "walletStatusError": "Wallet setup failed. Please retry or contact support if the issue continues."
 }

--- a/apps/web/src/helpers/sleep/index.test.ts
+++ b/apps/web/src/helpers/sleep/index.test.ts
@@ -1,0 +1,67 @@
+import { sleep, sleepInSeconds } from '.'
+
+describe('sleep utility function', () => {
+  it('sleep function should delay execution for the specified time', async () => {
+    vi.useFakeTimers()
+
+    const startTime = Date.now()
+    let hasResolved = false
+
+    const sleepPromise = sleep(1000).then(() => {
+      hasResolved = true
+    })
+
+    vi.advanceTimersByTime(500)
+    expect(hasResolved).toBe(false)
+
+    vi.advanceTimersByTime(500)
+    await sleepPromise
+
+    expect(hasResolved).toBe(true)
+
+    const endTime = Date.now()
+    expect(endTime - startTime).toBeLessThanOrEqual(1000)
+
+    vi.useRealTimers()
+  })
+
+  it('sleep function should resolve immediately for 0ms', async () => {
+    vi.useFakeTimers()
+
+    let hasResolved = false
+    const sleepPromise = sleep(0).then(() => {
+      hasResolved = true
+    })
+
+    vi.advanceTimersByTime(0)
+    await sleepPromise
+
+    expect(hasResolved).toBe(true)
+
+    vi.useRealTimers()
+  })
+
+  it('sleepInSeconds function should delay execution for the specified seconds', async () => {
+    vi.useFakeTimers()
+
+    const startTime = Date.now()
+    let hasResolved = false
+
+    const sleepPromise = sleepInSeconds(1).then(() => {
+      hasResolved = true
+    })
+
+    vi.advanceTimersByTime(500)
+    expect(hasResolved).toBe(false)
+
+    vi.advanceTimersByTime(500)
+    await sleepPromise
+
+    expect(hasResolved).toBe(true)
+
+    const endTime = Date.now()
+    expect(endTime - startTime).toBeLessThanOrEqual(1000)
+
+    vi.useRealTimers()
+  })
+})

--- a/apps/web/src/helpers/sleep/index.ts
+++ b/apps/web/src/helpers/sleep/index.ts
@@ -1,0 +1,7 @@
+export function sleep(ms: number): Promise<void> {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+export function sleepInSeconds(seconds: number): Promise<void> {
+  return sleep(seconds * 1000)
+}


### PR DESCRIPTION
### What

- Create wallet root route loader rules
     - Whenever a wallet status is not SUCCESS we will lock the user at a Loading Page
     - For error scenarios or wallet status equal FAILED we also have a Error Page
- Increases `get-wallet` endpoint pending wallet creation sleep interval to 2 seconds

### Why

- Enhance UX during wallet creation

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
