### PR TITLE
Feat(backend): create retryable interface and apply it on soroban interface

### DIFF
--- a/apps/backend/src/api/core/framework/retryable/interface.ts
+++ b/apps/backend/src/api/core/framework/retryable/interface.ts
@@ -1,0 +1,32 @@
+import { logger } from 'config/logger'
+
+export abstract class Retryable {
+  static async retry<T>(fn: () => Promise<T>, maxRetries = 3, baseDelayMs = 1000): Promise<T> {
+    let lastError: unknown
+
+    for (let attempt = 0; attempt <= maxRetries; attempt++) {
+      try {
+        return await fn()
+      } catch (err) {
+        lastError = err
+
+        if (attempt < maxRetries) {
+          const expBackoff = baseDelayMs * Math.pow(2, attempt)
+          const jitter = Math.random() * 200
+          const delay = expBackoff + jitter
+
+          logger.warn(
+            err,
+            `${this.constructor.name} | Attempt ${attempt + 1} failed. Retrying in ${delay.toFixed(0)}ms...`
+          )
+          await new Promise(resolve => setTimeout(resolve, delay))
+        }
+      }
+    }
+
+    if (lastError instanceof Error) {
+      throw lastError
+    }
+    throw new Error(String(lastError))
+  }
+}

--- a/apps/backend/src/api/core/framework/retryable/retryable.test.ts
+++ b/apps/backend/src/api/core/framework/retryable/retryable.test.ts
@@ -1,0 +1,57 @@
+import { logger } from 'config/logger'
+
+import { Retryable } from './interface'
+
+vi.mock('config/logger', () => ({
+  logger: {
+    warn: vi.fn(),
+  },
+}))
+
+describe('Retryable.retry', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should resolve immediately if fn succeeds on first try', async () => {
+    const fn = vi.fn().mockResolvedValue('success')
+
+    const result = await Retryable.retry(fn)
+
+    expect(result).toBe('success')
+    expect(fn).toHaveBeenCalledTimes(1)
+    expect(logger.warn).not.toHaveBeenCalled()
+  })
+
+  it('should retry until fn succeeds', async () => {
+    const fn = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('fail 1'))
+      .mockRejectedValueOnce(new Error('fail 2'))
+      .mockResolvedValue('finally success')
+
+    const result = await Retryable.retry(fn, 3, 1) // small baseDelay for test speed
+
+    expect(result).toBe('finally success')
+    expect(fn).toHaveBeenCalledTimes(3)
+    expect(logger.warn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should throw last error after all retries fail', async () => {
+    const fn = vi.fn().mockRejectedValue(new Error('always fails'))
+
+    await expect(Retryable.retry(fn, 2, 1)).rejects.toThrow('always fails')
+
+    expect(fn).toHaveBeenCalledTimes(3) // initial + 2 retries
+    expect(logger.warn).toHaveBeenCalledTimes(2)
+  })
+
+  it('should log retry messages with attempt count', async () => {
+    const error = new Error('fail')
+    const fn = vi.fn().mockRejectedValueOnce(error).mockResolvedValue('ok')
+
+    await Retryable.retry(fn, 2, 1)
+
+    expect(logger.warn).toHaveBeenCalledWith(error, expect.stringContaining('Attempt 1 failed'))
+  })
+})


### PR DESCRIPTION
### What

- Increases RPC server timeout
- Creates `retryable` interface
    - Abstract class that has a generic `retry` method. Useful to wrap any kind of promise that may require retries
- Update `soroban` interface to use `retryable` on every `rpc` call

### Why

- Improves the API to automatically handle blockchain delays

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
