### PR TITLE
hotfix: remove needless index from nft model

### DIFF
--- a/apps/backend/src/api/core/entities/nft/model.ts
+++ b/apps/backend/src/api/core/entities/nft/model.ts
@@ -12,7 +12,6 @@ import { NftSupply } from '../nft-supply/model'
 import { User } from '../user/model'
 
 @Entity()
-@Index(['nftSupply'], { unique: true })
 @Index(['tokenId', 'contractAddress'], { unique: true })
 export class Nft extends ModelBase {
   @PrimaryGeneratedColumn('uuid')

--- a/apps/backend/src/api/core/migrations/1755870848753-remove-nftSupply-unique-idx-from-nft.ts
+++ b/apps/backend/src/api/core/migrations/1755870848753-remove-nftSupply-unique-idx-from-nft.ts
@@ -1,0 +1,17 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class RemoveNftSupplyUniqueIdxFromNft1755870848753 implements MigrationInterface {
+  readonly name: string = 'RemoveNftSupplyUniqueIdxFromNft1755870848753'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_f021450a1d381ce2b23f0ff4e8"`)
+    await queryRunner.query(
+      `CREATE UNIQUE INDEX "IDX_0fca1a8c5d9399d9a9a52e26f7" ON "nft" ("token_id", "contract_address") `
+    )
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`DROP INDEX "public"."IDX_0fca1a8c5d9399d9a9a52e26f7"`)
+    await queryRunner.query(`CREATE UNIQUE INDEX "IDX_f021450a1d381ce2b23f0ff4e8" ON "nft" ("nft_supply_id") `)
+  }
+}


### PR DESCRIPTION
### What

Remove breaking contraint from nft model

### Why

Needless unique index breaking insert of new data.

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
