### PR TITLE
Fix(web): Catch Sentry errors

### DIFF
--- a/apps/web/src/app/core/error-boundary/index.tsx
+++ b/apps/web/src/app/core/error-boundary/index.tsx
@@ -2,6 +2,8 @@ import * as Sentry from '@sentry/react'
 import { ErrorInfo } from 'react'
 import { ErrorBoundary as ReactErrorBoundary, FallbackProps } from 'react-error-boundary'
 
+import logger from 'src/app/core/services/logger'
+
 import styles from './styles.module.css'
 
 export type ErrorBoundaryFallback = ({
@@ -42,13 +44,18 @@ const ErrorBoundary = ({
   children,
 }: IErrorBoundaryProps): JSX.Element => {
   const handleError = (error: Error, errorInfo: ErrorInfo) => {
-    const eventId = Sentry.captureException(error, {
-      contexts: {
-        react: {
-          componentStack: errorInfo.componentStack,
+    let eventId = null
+    try {
+      eventId = Sentry.captureException(error, {
+        contexts: {
+          react: {
+            componentStack: errorInfo.componentStack,
+          },
         },
-      },
-    })
+      })
+    } catch (sentryError) {
+      logger.warn('Failed to send error to Sentry:', sentryError)
+    }
     return eventId
   }
 

--- a/apps/web/src/instrument.ts
+++ b/apps/web/src/instrument.ts
@@ -5,27 +5,31 @@ import logger from 'src/app/core/services/logger'
 const dsn = import.meta.env.VITE_SENTRY_DSN
 
 if (dsn) {
-  const environment = import.meta.env.VITE_ENVIRONMENT_NAME || 'development'
+  try {
+    const environment = import.meta.env.VITE_ENVIRONMENT_NAME || 'development'
 
-  Sentry.init({
-    dsn,
-    environment,
-    release: import.meta.env.VITE_SENTRY_RELEASE || undefined,
+    Sentry.init({
+      dsn,
+      environment,
+      release: import.meta.env.VITE_SENTRY_RELEASE || undefined,
 
-    beforeSend(event) {
-      if (event.request?.headers) {
-        delete event.request.headers.authorization
-      }
+      beforeSend(event) {
+        if (event.request?.headers) {
+          delete event.request.headers.authorization
+        }
 
-      return event
-    },
+        return event
+      },
 
-    sendDefaultPii: false,
-    attachStacktrace: true,
-    debug: environment !== 'production',
-  })
+      sendDefaultPii: false,
+      attachStacktrace: true,
+      debug: environment !== 'production',
+    })
 
-  logger.log('Sentry initialized successfully')
+    logger.log('Sentry initialized successfully')
+  } catch (sentryError) {
+    logger.warn('Failed to initialize Sentry:', sentryError)
+  }
 } else {
   logger.log('Sentry DSN not configured, skipping initialization')
 }


### PR DESCRIPTION
### What

This catches Sentry errors so that they are not visible to the user.

### Why

Sentry requests can fail for users with ad blockers installed.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
