### PR TITLE
Fix(web): special gift template overlapping text

### DIFF
--- a/apps/web/src/app/wallet/pages/special-gift/template.tsx
+++ b/apps/web/src/app/wallet/pages/special-gift/template.tsx
@@ -3,7 +3,6 @@ import Skeleton from 'react-loading-skeleton'
 
 import { Typography, TypographyVariant } from 'src/components/atoms'
 import { GhostButton } from 'src/components/molecules'
-import { SafeAreaView } from 'src/components/organisms'
 import { a } from 'src/interfaces/cms/useAssets'
 import { c } from 'src/interfaces/cms/useContent'
 
@@ -27,66 +26,68 @@ export const SpecialGiftTemplate = ({
   onShareImage,
 }: Props) => {
   return (
-    <SafeAreaView>
-      {/* Centered component */}
-      <div className="absolute flex flex-col inset-0 py-8 px-4 items-center justify-center gap-6">
-        <div className="flex flex-col bg-background p-4 drop-shadow-lg items-center gap-4">
-          <img src={imageUri} alt="Special gift image" />
+    <div className="flex flex-col min-h-screen">
+      {/* Scrollable + Centerable content */}
+      <div className="flex-1 overflow-y-auto flex justify-center items-center">
+        <div className="flex flex-col items-center justify-center gap-6 py-8 px-4 min-h-full">
+          <div className="flex flex-col bg-background p-4 drop-shadow-lg items-center gap-4">
+            <img src={imageUri} alt="Special gift image" className="max-w-full h-auto object-contain" />
 
-          <div className="flex gap-4">
-            <img className="text-primary" src={a('yellowLogo')} width={32} alt="Logo" />
-            <Typography variant={TypographyVariant.h1Brand} className="text-3xl">
-              {c('specialGiftTitle')}
-            </Typography>
-          </div>
-        </div>
-
-        <div className="flex flex-col w-full gap-4">
-          {isCheckingGiftEligibility ? (
-            <Skeleton height={40} borderRadius={'1.25rem'} />
-          ) : (
-            <div className="flex flex-col gap-[10px]">
-              <Button
-                disabled={isGiftClaimed}
-                variant={'secondary'}
-                size="lg"
-                onClick={onClaimGift}
-                isRounded
-                isFullWidth
-              >
-                {c('claimGift')}
-              </Button>
-              {isGiftClaimed && (
-                <div className="text-center text-textSecondary">
-                  <Text as={'p'} size="sm" weight="medium">
-                    {c('specialGiftClaimedDescription')}
-                  </Text>
-                </div>
-              )}
+            <div className="flex gap-4">
+              <img className="text-primary" src={a('yellowLogo')} width={32} alt="Logo" />
+              <Typography variant={TypographyVariant.h1Brand} className="text-3xl">
+                {c('specialGiftTitle')}
+              </Typography>
             </div>
-          )}
+          </div>
 
-          <Button
-            isLoading={isSharingImage}
-            variant={'tertiary'}
-            size="lg"
-            onClick={onShareImage}
-            icon={<Icon.Share01 />}
-            iconPosition="left"
-            isRounded
-            isFullWidth
-          >
-            {c('shareImage')}
-          </Button>
+          <div className="flex flex-col w-full gap-4">
+            {isCheckingGiftEligibility ? (
+              <Skeleton height={40} borderRadius={'1.25rem'} />
+            ) : (
+              <div className="flex flex-col gap-[10px]">
+                <Button
+                  disabled={isGiftClaimed}
+                  variant={'secondary'}
+                  size="lg"
+                  onClick={onClaimGift}
+                  isRounded
+                  isFullWidth
+                >
+                  {c('claimGift')}
+                </Button>
+                {isGiftClaimed && (
+                  <div className="text-center text-textSecondary">
+                    <Text as={'p'} size="sm" weight="medium">
+                      {c('specialGiftClaimedDescription')}
+                    </Text>
+                  </div>
+                )}
+              </div>
+            )}
+
+            <Button
+              isLoading={isSharingImage}
+              variant={'tertiary'}
+              size="lg"
+              onClick={onShareImage}
+              icon={<Icon.Share01 />}
+              iconPosition="left"
+              isRounded
+              isFullWidth
+            >
+              {c('shareImage')}
+            </Button>
+          </div>
         </div>
       </div>
 
-      {/* Bottom component */}
-      <div className="absolute bottom-0 left-0 right-0 flex justify-center py-8 px-4">
+      {/* Sticky footer */}
+      <div className="sticky bottom-0 left-0 right-0 flex justify-center bg-background pt-4 pb-8 px-4 shadow-[0_-2px_8px_rgba(0,0,0,0.1)]">
         <GhostButton size="lg" onClick={onGoBack}>
           {c('specialGiftGoBackButtonText')}
         </GhostButton>
       </div>
-    </SafeAreaView>
+    </div>
   )
 }


### PR DESCRIPTION
### What

- Fixes the `special-gift` template to stop overlapping text when images have vertical proportion

### Why

- It should not overlap components for any kind of image

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
