### PR TITLE
Feat(web): transfer assets tab UI

### DIFF
--- a/apps/web/src/app/core/utils/format-stellar-address/index.ts
+++ b/apps/web/src/app/core/utils/format-stellar-address/index.ts
@@ -4,12 +4,17 @@ import { StrKey } from '@stellar/stellar-sdk'
  * Shortens a Stellar wallet address to 8 characters or less, e.g. "G...1234"
  * @param fullAddress - The full Stellar wallet address
  * @param options.onlyValidAddress - If true, only return a shortened version if the fullAddress is a valid Stellar address
+ * @param options.sliceAmount - The number of characters to slice from the start and end
  * @returns A shortened version of the Stellar wallet address
  */
-export const createShortStellarAddress = (fullAddress: string, options?: { onlyValidAddress?: boolean }): string => {
+export const createShortStellarAddress = (
+  fullAddress: string,
+  options?: { onlyValidAddress?: boolean; sliceAmount?: number }
+): string => {
   if (options?.onlyValidAddress && !isValidStellarAddress(fullAddress)) return fullAddress
-  if (fullAddress.length <= 8) return fullAddress
-  return `${fullAddress.slice(0, 4)}...${fullAddress.slice(-4)}`
+  const sliceAmount = options?.sliceAmount || 4
+  if (fullAddress.length <= sliceAmount * 2) return fullAddress
+  return `${fullAddress.slice(0, sliceAmount)}...${fullAddress.slice(-sliceAmount)}`
 }
 
 /**
@@ -20,6 +25,19 @@ export const createShortStellarAddress = (fullAddress: string, options?: { onlyV
 export const isValidStellarAddress = (text: string): boolean => {
   try {
     return StrKey.isValidEd25519PublicKey(text) || StrKey.isValidContract(text)
+  } catch {
+    return false
+  }
+}
+
+/**
+ * Checks if the given string is a valid Stellar Contract address
+ * @param text - The string to check
+ * @returns True if the string is a valid Stellar Contract address, false otherwise
+ */
+export const isValidStellarContractAddress = (text: string): boolean => {
+  try {
+    return StrKey.isValidContract(text)
   } catch {
     return false
   }

--- a/apps/web/src/app/wallet/components/index.ts
+++ b/apps/web/src/app/wallet/components/index.ts
@@ -1,2 +1,3 @@
 export * from './empty-list'
 export * from './view-nft-drawer'
+export * from './wallet-address-form'

--- a/apps/web/src/app/wallet/components/wallet-address-form/index.tsx
+++ b/apps/web/src/app/wallet/components/wallet-address-form/index.tsx
@@ -1,0 +1,87 @@
+import { Link, Text } from '@stellar/design-system'
+import clsx from 'clsx'
+import { UseFormReturn } from 'react-hook-form'
+
+import { createShortStellarAddress } from 'src/app/core/utils'
+import { Form } from 'src/components/organisms'
+import { c } from 'src/interfaces/cms/useContent'
+
+import { WalletAddressFormValues } from './schema'
+
+type Props = {
+  isSubmitDisabled?: boolean
+  form: UseFormReturn<WalletAddressFormValues>
+  submitButtonText: string
+  submitVariant?: 'default' | 'outside'
+  onSubmit: (values: WalletAddressFormValues) => void
+}
+
+export const WalletAddressForm = ({
+  isSubmitDisabled,
+  form,
+  submitButtonText,
+  submitVariant = 'default',
+  onSubmit,
+}: Props) => {
+  const { watch } = form
+  const walletAddressValue = watch('walletAddress')
+
+  return (
+    <Form form={form} onSubmit={onSubmit}>
+      <div className="flex flex-col gap-4">
+        <div className={clsx(submitVariant === 'outside' && 'rounded-lg bg-background p-4')}>
+          <div className="flex flex-col gap-2 justify-center">
+            <Form.Input
+              name="walletAddress"
+              value={walletAddressValue ? createShortStellarAddress(walletAddressValue, { sliceAmount: 9 }) : ''}
+              fieldSize="lg"
+              label={c('walletAddressFormLabel')}
+              placeholder={c('walletAddressFormPlaceholder')}
+              rightElement={
+                <button
+                  type="button"
+                  onClick={e => {
+                    e.preventDefault()
+                    navigator.clipboard.readText().then(text => {
+                      form.setValue('walletAddress', text)
+                    })
+                  }}
+                  className={clsx(
+                    'flex items-center justify-center px-2 h-6 rounded-full border border-borderPrimary',
+                    'bg-backgroundPrimary text-text',
+                    'active:text-textSecondary active:border-borderSecondary',
+                    'transition-colors'
+                  )}
+                >
+                  <Text as="span" size="xs" weight="semi-bold">
+                    {c('paste')}
+                  </Text>
+                </button>
+              }
+              disabled
+            />
+
+            <div className="text-center">
+              {/* TODO: add link/action */}
+              <Link addlClassName="font-semibold" size="sm">
+                {c('walletAddressFormNoWalletLink')}
+              </Link>
+            </div>
+          </div>
+        </div>
+
+        <div>
+          <Form.Submit
+            variant="secondary"
+            size="xl"
+            disabled={isSubmitDisabled || walletAddressValue === ''}
+            isRounded
+            isFullWidth
+          >
+            {submitButtonText}
+          </Form.Submit>
+        </div>
+      </div>
+    </Form>
+  )
+}

--- a/apps/web/src/app/wallet/components/wallet-address-form/schema.ts
+++ b/apps/web/src/app/wallet/components/wallet-address-form/schema.ts
@@ -1,0 +1,25 @@
+import * as yup from 'yup'
+
+import { isValidStellarContractAddress } from 'src/app/core/utils'
+
+// TODO: Add restricted addresses
+const restrictedAddresses: string[] = []
+
+// Schema definition
+export const walletAddressFormSchema = yup.object({
+  walletAddress: yup
+    .string()
+    .required('Wallet address is required')
+    .test(
+      'is-valid-contract',
+      'Use a wallet address starting with G',
+      value => !value || isValidStellarContractAddress(value)
+    )
+    .test(
+      'is-restricted',
+      'This account requires memo. Use different one.',
+      value => !value || !restrictedAddresses.includes(value)
+    ),
+})
+
+export type WalletAddressFormValues = yup.InferType<typeof walletAddressFormSchema>

--- a/apps/web/src/app/wallet/pages/home/template.tsx
+++ b/apps/web/src/app/wallet/pages/home/template.tsx
@@ -197,7 +197,7 @@ export const HomeTemplate = ({
   const Faq = () => (
     <Collapse title={faq.title}>
       {faq.items.map((item, index) => (
-        <CollapseItem key={index} title={item.title}>
+        <CollapseItem key={index} title={{ text: item.title }}>
           <Text as={'p'} size={'sm'}>
             {item.description}
           </Text>

--- a/apps/web/src/app/wallet/pages/left-assets/tabs/transfer-assets/index.tsx
+++ b/apps/web/src/app/wallet/pages/left-assets/tabs/transfer-assets/index.tsx
@@ -1,19 +1,55 @@
-import { useState } from 'react'
+import { yupResolver } from '@hookform/resolvers/yup'
+import { useMemo } from 'react'
+import { useForm } from 'react-hook-form'
 
-import TransferAssetsTemplate from './template'
+import { walletAddressFormSchema, WalletAddressFormValues } from 'src/app/wallet/components/wallet-address-form/schema'
+import { useGetWallet } from 'src/app/wallet/queries/use-get-wallet'
+
+import TransferAssetsTemplate, { Organization } from './template'
 
 export const TransferAssets = () => {
-  const [isLoading] = useState(false)
+  const getWallet = useGetWallet()
+  const walletData = getWallet.data
 
-  if (isLoading) {
-    return (
-      <div className="flex justify-center items-center py-12">
-        <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-brandPrimary"></div>
-      </div>
-    )
+  const standardTransferForm = useForm<WalletAddressFormValues>({
+    resolver: yupResolver(walletAddressFormSchema),
+    mode: 'onSubmit',
+  })
+
+  const mockOrganizations = [
+    {
+      title: 'Stellar Foundation',
+      description: 'Stellar Foundation description',
+      imageUri: 'https://en.cryptonomist.ch/wp-content/uploads/2022/10/robinhood-stellar-xlm.jpg',
+      walletAddress: 'GDQGQYV6Q7D6VY7VY7VY7VY7VY7VY7VY7VY7VY7VY7VY7VY7VY7VY7VY7VY7VY7VY7VY7VY7',
+    },
+  ]
+
+  const handleOrganizationClick = (_organization: Organization) => {
+    // TODO: open transfer drawer function
+    alert('Organization clicked')
   }
 
-  return <TransferAssetsTemplate />
+  const handleStandardTransferSubmit = async (_values: WalletAddressFormValues) => {
+    // TODO: call transfer function
+  }
+
+  const isLoadingBalance = useMemo(() => {
+    if (typeof walletData?.balance === 'undefined') return true
+
+    return getWallet.isLoading || getWallet.isError
+  }, [getWallet.isError, getWallet.isLoading, walletData?.balance])
+
+  return (
+    <TransferAssetsTemplate
+      isLoadingBalance={isLoadingBalance}
+      balanceAmount={walletData?.balance || 0}
+      organizations={mockOrganizations}
+      standardTransferForm={standardTransferForm}
+      onOrganizationClick={handleOrganizationClick}
+      onStandardTransferSubmit={handleStandardTransferSubmit}
+    />
+  )
 }
 
 export default TransferAssets

--- a/apps/web/src/app/wallet/pages/left-assets/tabs/transfer-assets/template.tsx
+++ b/apps/web/src/app/wallet/pages/left-assets/tabs/transfer-assets/template.tsx
@@ -1,10 +1,123 @@
-export const TransferAssetsTemplate = () => {
-  return (
+import { Badge, Text, Notification } from '@stellar/design-system'
+import clsx from 'clsx'
+import { UseFormReturn } from 'react-hook-form'
+import Skeleton from 'react-loading-skeleton'
+
+import { formatNumber } from 'src/app/core/utils'
+import { WalletAddressForm } from 'src/app/wallet/components'
+import { WalletAddressFormValues } from 'src/app/wallet/components/wallet-address-form/schema'
+import { AssetAmount } from 'src/components/molecules'
+import { Collapse, CollapseItem } from 'src/components/organisms'
+import { c } from 'src/interfaces/cms/useContent'
+
+export type Organization = {
+  title: string
+  description: string
+  imageUri: string
+  walletAddress: string
+}
+
+type Props = {
+  isLoadingBalance: boolean
+  balanceAmount: number
+  organizations: Organization[]
+  standardTransferForm: UseFormReturn<WalletAddressFormValues>
+  onOrganizationClick: (organization: Organization) => void
+  onStandardTransferSubmit: (values: WalletAddressFormValues) => void
+}
+
+export const TransferAssetsTemplate = ({
+  isLoadingBalance,
+  balanceAmount,
+  organizations,
+  standardTransferForm,
+  onOrganizationClick,
+  onStandardTransferSubmit,
+}: Props) => {
+  const OrganizationItem = ({ organization }: { organization: Organization }) => (
+    <div>
+      <button
+        className={clsx(
+          'w-full flex flex-col rounded-xl gap-2 py-3 px-4 text-left border border-borderPrimary',
+          'active:shadow-sm active:border-borderSecondary'
+        )}
+        onClick={() => onOrganizationClick(organization)}
+      >
+        <div className="w-full flex items-center justify-between">
+          <div className="text-text">
+            <Text as="span" size={'sm'} weight={'medium'}>
+              {organization.title}
+            </Text>
+          </div>
+
+          <div>
+            <img src={organization.imageUri} alt={organization.title} className="max-h-[16px]" />
+          </div>
+        </div>
+
+        <div className="text-textSecondary">
+          <Text as="p" size="sm">
+            {organization.description}
+          </Text>
+        </div>
+      </button>
+    </div>
+  )
+
+  const OrganizationList = () => (
     <div className="flex flex-col gap-6">
-      <div className="p-4 border rounded-lg">
-        <h3 className="text-lg font-semibold mb-4">Transfer Assets</h3>
-        <p className="text-gray-600">Template for asset transfer</p>
+      {organizations.map(organization => (
+        <OrganizationItem key={organization.title} organization={organization} />
+      ))}
+    </div>
+  )
+
+  const StandardTransfer = () => (
+    <div className="flex flex-col gap-4">
+      {isLoadingBalance ? (
+        <Skeleton height={32} />
+      ) : (
+        <AssetAmount amount={balanceAmount} size="lg" asset={{ value: 'XLM', variant: 'sm' }} />
+      )}
+
+      <WalletAddressForm
+        form={standardTransferForm}
+        submitButtonText={c('transfer')}
+        onSubmit={onStandardTransferSubmit}
+      />
+      <Notification variant="warning" title={c('transferAssetsStandardTransferDisclaimer')} />
+    </div>
+  )
+
+  return (
+    <div className="flex flex-col gap-2 p-4 rounded-2xl bg-background">
+      <div className="flex">
+        {isLoadingBalance ? (
+          <Skeleton width={150} borderRadius={'6.25rem'} />
+        ) : (
+          <Badge variant="secondary">{`${formatNumber(balanceAmount)} ${c('transferAssetsBalanceText')}`}</Badge>
+        )}
       </div>
+
+      <Collapse>
+        <CollapseItem
+          title={{ text: c('transferAssetsOrganizationListTitle'), size: 'md', weight: 'semi-bold' }}
+          description={{
+            text: c('transferAssetsOrganizationListDescription'),
+          }}
+        >
+          <OrganizationList />
+        </CollapseItem>
+
+        <CollapseItem
+          title={{ text: c('transferAssetsStandardTransferTitle'), size: 'md', weight: 'semi-bold' }}
+          description={{
+            text: c('transferAssetsStandardTransferDescription'),
+          }}
+        >
+          <StandardTransfer />
+        </CollapseItem>
+      </Collapse>
     </div>
   )
 }

--- a/apps/web/src/app/wallet/pages/left-assets/tabs/transfer-nfts/index.tsx
+++ b/apps/web/src/app/wallet/pages/left-assets/tabs/transfer-nfts/index.tsx
@@ -1,5 +1,8 @@
+import { yupResolver } from '@hookform/resolvers/yup'
 import { useState, useMemo } from 'react'
+import { useForm } from 'react-hook-form'
 
+import { walletAddressFormSchema, WalletAddressFormValues } from 'src/app/wallet/components/wallet-address-form/schema'
 import { Loading } from 'src/components/atoms'
 
 import TransferNftsTemplate from './template'
@@ -8,9 +11,13 @@ import { Nft } from '../../../../services/wallet/types'
 
 export const TransferNfts = () => {
   const [selectedNfts, setSelectedNfts] = useState<Set<string>>(new Set())
-  const [walletAddress, setWalletAddress] = useState('')
 
   const { data: nftsData, isLoading: isLoadingNfts } = useGetNfts()
+
+  const nftsReviewForm = useForm<WalletAddressFormValues>({
+    resolver: yupResolver(walletAddressFormSchema),
+    mode: 'onSubmit',
+  })
 
   const nfts = useMemo((): Nft[] => {
     if (!nftsData?.data?.nfts) return []
@@ -33,13 +40,8 @@ export const TransferNfts = () => {
     setSelectedNfts(newSelected)
   }
 
-  const handleWalletAddressChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setWalletAddress(e.target.value)
-  }
-
-  const handlePaste = async () => {
-    const text = await navigator.clipboard.readText()
-    setWalletAddress(text)
+  const handleReview = (_values: WalletAddressFormValues) => {
+    // TODO: open transfer drawer function
   }
 
   if (isLoadingNfts) {
@@ -54,11 +56,9 @@ export const TransferNfts = () => {
     <TransferNftsTemplate
       nfts={nfts}
       selectedNfts={selectedNfts}
-      walletAddress={walletAddress}
+      nftsReviewForm={nftsReviewForm}
       onNftToggle={handleNftToggle}
-      onWalletAddressChange={handleWalletAddressChange}
-      onPaste={handlePaste}
-      onReview={handlePaste}
+      onReview={handleReview}
     />
   )
 }

--- a/apps/web/src/app/wallet/pages/left-assets/tabs/transfer-nfts/template.tsx
+++ b/apps/web/src/app/wallet/pages/left-assets/tabs/transfer-nfts/template.tsx
@@ -1,5 +1,8 @@
-import { Button, Text, Icon, Input } from '@stellar/design-system'
+import { Text, Icon } from '@stellar/design-system'
+import { UseFormReturn } from 'react-hook-form'
 
+import { WalletAddressForm } from 'src/app/wallet/components'
+import { WalletAddressFormValues } from 'src/app/wallet/components/wallet-address-form/schema'
 import { ImageCard } from 'src/components/organisms'
 import { c } from 'src/interfaces/cms/useContent'
 
@@ -8,28 +11,24 @@ import { Nft } from '../../../../services/wallet/types'
 interface TransferNftsTemplateProps {
   nfts: Nft[]
   selectedNfts: Set<string>
-  walletAddress: string
+  nftsReviewForm: UseFormReturn<WalletAddressFormValues>
   onNftToggle: (nftId: string) => void
-  onWalletAddressChange: (e: React.ChangeEvent<HTMLInputElement>) => void
-  onPaste: () => void
-  onReview: () => void
+  onReview: (values: WalletAddressFormValues) => void
 }
 
 export const TransferNftsTemplate = ({
   nfts,
   selectedNfts,
-  walletAddress,
+  nftsReviewForm,
   onNftToggle,
-  onWalletAddressChange,
-  onPaste,
   onReview,
 }: TransferNftsTemplateProps) => {
-  const isReviewDisabled = selectedNfts.size === 0 || !walletAddress.trim()
+  const isReviewDisabled = selectedNfts.size === 0
 
   if (nfts.length === 0) {
     return (
       <div className="flex flex-col gap-6">
-        <div className="bg-background rounded-lg p-6 shadow-sm border border-borderSecondary">
+        <div className="bg-background rounded-2xl p-6 shadow-sm border-borderSecondary">
           <div className="text-center py-8">
             <Text as="p" size="md" className="text-textSecondary">
               {c('transferNftsNoNftsAvailable')}
@@ -42,7 +41,7 @@ export const TransferNftsTemplate = ({
 
   return (
     <div className="flex flex-col gap-4">
-      <div className="rounded-lg">
+      <div className="rounded-2xl">
         <div className="grid grid-cols-2 gap-3">
           {nfts.map(nft => {
             const nftId = nft.id || ''
@@ -63,38 +62,13 @@ export const TransferNftsTemplate = ({
         </div>
       </div>
 
-      <div className="bg-background rounded-lg p-6 shadow-sm border border-borderSecondary">
-        <div className="space-y-3">
-          <Input
-            id="wallet-address"
-            fieldSize="lg"
-            label={c('transferNftsWalletAddressLabel')}
-            placeholder={c('transferNftsWalletAddressPlaceholder')}
-            value={walletAddress}
-            onChange={onWalletAddressChange}
-            rightElement={
-              <button
-                onClick={onPaste}
-                className="px-2 rounded-full border border-borderPrimary bg-backgroundPrimary hover:bg-muted transition-colors"
-              >
-                <Text as="span" size="md" className="font-semibold text-text text-xs">
-                  {c('transferNftsPasteButton')}
-                </Text>
-              </button>
-            }
-          />
-
-          <div className="text-center text-brandPrimary">
-            <Text as="p" size="xs" className="font-semibold text-sm">
-              {c('transferNftsNoWalletMessage')}
-            </Text>
-          </div>
-        </div>
-      </div>
-
-      <Button variant="secondary" size="xl" isRounded isFullWidth disabled={isReviewDisabled} onClick={onReview}>
-        {c('transferNftsReviewButton')}
-      </Button>
+      <WalletAddressForm
+        form={nftsReviewForm}
+        submitButtonText={c('transferNftsReviewButton')}
+        submitVariant="outside"
+        isSubmitDisabled={isReviewDisabled}
+        onSubmit={onReview}
+      />
 
       <div className="border border-borderPrimary rounded-lg p-3 flex gap-3">
         <div className="flex-shrink-0 w-8 h-8 flex items-center justify-center">

--- a/apps/web/src/components/atoms/slider/index.tsx
+++ b/apps/web/src/components/atoms/slider/index.tsx
@@ -23,6 +23,7 @@ const SLIDER_COLOR_STYLE: Record<ThemeColor, string> = {
   accentMuted: 'bg-accent-muted',
   foreground: 'bg-foreground',
   background: 'bg-background',
+  backgroundPrimary: 'bg-background-primary',
   backgroundSecondary: 'bg-background-secondary',
   backgroundTertiary: 'bg-background-tertiary',
   borderPrimary: 'bg-border-primary',

--- a/apps/web/src/components/molecules/asset-amount/index.tsx
+++ b/apps/web/src/components/molecules/asset-amount/index.tsx
@@ -28,19 +28,19 @@ export const AssetAmount = ({ amount, amountVariant = 'default', size = 'md', we
     switch (size) {
       case 'sm':
         return (
-          <Text as="span" size="sm" weight={weight}>
+          <Text addlClassName="text-text" as="span" size="sm" weight={weight}>
             {formattedAmount}
           </Text>
         )
       case 'md':
         return (
-          <Heading as={'h2'} size={'xs'} weight={weight}>
+          <Heading addlClassName="text-text" as={'h2'} size={'xs'} weight={weight}>
             {formattedAmount}
           </Heading>
         )
       case 'lg':
         return (
-          <Heading as={'h1'} size={'xs'} weight={weight}>
+          <Heading addlClassName="text-text" as={'h1'} size={'xs'} weight={weight}>
             {formattedAmount}
           </Heading>
         )

--- a/apps/web/src/components/organisms/collapse/collapse.test.tsx
+++ b/apps/web/src/components/organisms/collapse/collapse.test.tsx
@@ -5,10 +5,13 @@ import { Collapse, CollapseItem } from '.'
 describe('CollapseItem', () => {
   it('renders title and children (collapsed by default)', () => {
     render(
-      <CollapseItem title="Item 1">
+      <CollapseItem title={{ text: 'Item 1' }}>
         <div>Content 1</div>
       </CollapseItem>
     )
+
+    const button = screen.getByRole('button', { name: /Item 1/i })
+    fireEvent.click(button)
 
     expect(screen.getByText('Item 1')).toBeInTheDocument()
     expect(screen.queryByText('Content 1')).toBeInTheDocument()
@@ -20,7 +23,7 @@ describe('CollapseItem', () => {
 
   it('expands on click', () => {
     render(
-      <CollapseItem title="Item 2">
+      <CollapseItem title={{ text: 'Item 2' }}>
         <div>Content 2</div>
       </CollapseItem>
     )
@@ -36,7 +39,7 @@ describe('CollapseItem', () => {
 
   it('starts expanded when defaultOpen is true', () => {
     render(
-      <CollapseItem title="Item 3" defaultOpen>
+      <CollapseItem title={{ text: 'Item 3' }} defaultOpen>
         <div>Content 3</div>
       </CollapseItem>
     )
@@ -52,11 +55,14 @@ describe('Collapse', () => {
   it('renders title and children items', () => {
     render(
       <Collapse title="FAQ">
-        <CollapseItem title="Q1">
+        <CollapseItem title={{ text: 'Q1' }}>
           <div>A1</div>
         </CollapseItem>
       </Collapse>
     )
+
+    const button = screen.getByRole('button', { name: /Q1/i })
+    fireEvent.click(button)
 
     expect(screen.getByText('FAQ')).toBeInTheDocument()
     expect(screen.getByText('Q1')).toBeInTheDocument()
@@ -66,10 +72,10 @@ describe('Collapse', () => {
   it('renders multiple CollapseItem children', () => {
     render(
       <Collapse title="FAQ">
-        <CollapseItem title="Q1">
+        <CollapseItem title={{ text: 'Q1' }}>
           <div>A1</div>
         </CollapseItem>
-        <CollapseItem title="Q2">
+        <CollapseItem title={{ text: 'Q2' }}>
           <div>A2</div>
         </CollapseItem>
       </Collapse>

--- a/apps/web/src/config/content.example.json
+++ b/apps/web/src/config/content.example.json
@@ -112,10 +112,16 @@
   "transferAssetsTabLabel": "Transfer Assets",
   "transferNftsTabLabel": "Transfer NFTs",
   "transferNftsNoNftsAvailable": "No NFTs available for transfer",
-  "transferNftsWalletAddressLabel": "Enter Wallet Address",
-  "transferNftsWalletAddressPlaceholder": "G...",
-  "transferNftsPasteButton": "Paste",
-  "transferNftsNoWalletMessage": "Don't have a wallet yet? Try Freighter",
+  "walletAddressFormLabel": "Enter Stellar Wallet Address",
+  "walletAddressFormPlaceholder": "G...",
+  "paste": "Paste",
+  "walletAddressFormNoWalletLink": "Don't have a wallet yet? Try Freighter",
   "transferNftsReviewButton": "Review",
-  "transferNftsAlertTitle": "You can send NFTs to any Stellar address but not all wallets display them appropriately. Freighter does!"
+  "transferNftsAlertTitle": "You can send NFTs to any Stellar address but not all wallets display them appropriately. Freighter does!",
+  "transferAssetsBalanceText": "XLM",
+  "transferAssetsOrganizationListTitle": "Transfer to Organizations",
+  "transferAssetsOrganizationListDescription": "Transfer XLM to trusted organizations on Stellar. Any XLM can be transferred to another Stellar wallet.",
+  "transferAssetsStandardTransferTitle": "Transfer XLM",
+  "transferAssetsStandardTransferDescription": "Transfer any XLM to a personal Stellar wallet.",
+  "transferAssetsStandardTransferDisclaimer": "Do not transfer to accounts that require a Stellar memo, including exchanges like Coinbase. You could lose funds."
 }

--- a/apps/web/src/config/theme/theme.ts
+++ b/apps/web/src/config/theme/theme.ts
@@ -17,6 +17,7 @@ export const THEME_STYLES = {
         textTertiary: 'var(--color-text-tertiary)',
         foreground: 'var(--color-foreground-primary)',
         background: 'var(--color-background)',
+        backgroundPrimary: 'var(--color-background-primary)',
         backgroundSecondary: 'var(--color-background-secondary)',
         backgroundTertiary: 'var(--color-background-tertiary)',
         borderPrimary: 'var(--color-border-primary)',


### PR DESCRIPTION
### What

- Refactors `collapse` component, adding animation, description and optional title
- Creates `wallet-address-form` components to be used on `left-assets` page (on tabs)
- Creates `transfer assets tab` structure and template

### Why

- Tab necessary to perform standard transfer to external wallets or to organizations

### Visual





| | | | |
|--------|--------|--------|--------|
| <img width="404" height="736" alt="Screenshot 2025-08-26 at 17 56 43" src="https://github.com/user-attachments/assets/c5216236-6b6b-488e-8275-26a96f8e69bd" /> | <img width="404" height="739" alt="Screenshot 2025-08-26 at 17 56 49" src="https://github.com/user-attachments/assets/3b70473a-a3f3-4e67-996f-990dbf1bbeb7" /> | <img width="405" height="739" alt="Screenshot 2025-08-26 at 17 56 58" src="https://github.com/user-attachments/assets/d8ce14e8-6983-44d6-8859-e04372c83168" /> | <img width="408" height="738" alt="Screenshot 2025-08-26 at 17 57 07" src="https://github.com/user-attachments/assets/9092c2e2-8f1f-490f-92ab-da986b71d9c1" /> | 


### Checklist



#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
