### PR TITLE
fix (backend): claim nft options supply find

### DIFF
--- a/apps/backend/src/api/embedded-wallets/use-cases/claim-nft-options/index.test.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/claim-nft-options/index.test.ts
@@ -131,7 +131,7 @@ describe('ClaimNftOptions', () => {
       const res = mockResponse()
 
       mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
-      mockedNftSupplyRepository.getNftSupplyByResource.mockResolvedValue(mockNftSupply)
+      mockedNftSupplyRepository.getNftSupplyByResourceAndSessionId.mockResolvedValue(mockNftSupply)
       mockedNftRepository.getNftByUserAndSessionId.mockResolvedValue(null)
 
       await claimNftOptions.executeHttp(req, res)
@@ -155,7 +155,7 @@ describe('ClaimNftOptions', () => {
       const res = mockResponse()
 
       mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
-      mockedNftSupplyRepository.getNftSupplyByResource.mockResolvedValue(mockNftSupply)
+      mockedNftSupplyRepository.getNftSupplyByResourceAndSessionId.mockResolvedValue(mockNftSupply)
       mockedNftRepository.getNftByUserAndSessionId.mockResolvedValue(null)
 
       await claimNftOptions.executeHttp(req, res)
@@ -189,8 +189,8 @@ describe('ClaimNftOptions', () => {
       })
       mockedUserRepository.getUserByEmail.mockResolvedValue(userWithoutWallet)
       // Ensure NFT supply repository returns null to prevent the function from continuing
-      mockedNftSupplyRepository.getNftSupplyByResource.mockResolvedValue(null)
-      mockedNftSupplyRepository.getNftSupplyByContractAddress.mockResolvedValue(null)
+      mockedNftSupplyRepository.getNftSupplyByResourceAndSessionId.mockResolvedValue(null)
+      mockedNftSupplyRepository.getNftSupplyByContractAndSessionId.mockResolvedValue(null)
 
       const payload: RequestSchemaT = {
         email: 'test@example.com',
@@ -224,8 +224,8 @@ describe('ClaimNftOptions', () => {
 
     it('should throw ResourceNotFoundException if NFT supply is not found by resource', async () => {
       mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
-      mockedNftSupplyRepository.getNftSupplyByResource.mockResolvedValue(null)
-      mockedNftSupplyRepository.getNftSupplyByContractAddress.mockResolvedValue(null)
+      mockedNftSupplyRepository.getNftSupplyByResourceAndSessionId.mockResolvedValue(null)
+      mockedNftSupplyRepository.getNftSupplyByContractAndSessionId.mockResolvedValue(null)
 
       const payload: RequestSchemaT = {
         email: 'test@example.com',
@@ -234,14 +234,20 @@ describe('ClaimNftOptions', () => {
       }
 
       await expect(claimNftOptions.handle(payload)).rejects.toThrow(ResourceNotFoundException)
-      expect(mockedNftSupplyRepository.getNftSupplyByResource).toHaveBeenCalledWith('nonexistent-resource')
-      expect(mockedNftSupplyRepository.getNftSupplyByContractAddress).toHaveBeenCalledWith('nonexistent-resource')
+      expect(mockedNftSupplyRepository.getNftSupplyByResourceAndSessionId).toHaveBeenCalledWith(
+        'nonexistent-resource',
+        'session-123'
+      )
+      expect(mockedNftSupplyRepository.getNftSupplyByContractAndSessionId).toHaveBeenCalledWith(
+        'nonexistent-resource',
+        'session-123'
+      )
     })
 
     it('should find NFT supply by contract address when not found by resource', async () => {
       mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
-      mockedNftSupplyRepository.getNftSupplyByResource.mockResolvedValue(null)
-      mockedNftSupplyRepository.getNftSupplyByContractAddress.mockResolvedValue(mockNftSupply)
+      mockedNftSupplyRepository.getNftSupplyByResourceAndSessionId.mockResolvedValue(null)
+      mockedNftSupplyRepository.getNftSupplyByContractAndSessionId.mockResolvedValue(mockNftSupply)
       mockedNftRepository.getNftByUserAndSessionId.mockResolvedValue(null)
 
       const payload: RequestSchemaT = {
@@ -260,8 +266,14 @@ describe('ClaimNftOptions', () => {
         },
         message: 'Retrieved NFT options successfully',
       })
-      expect(mockedNftSupplyRepository.getNftSupplyByResource).toHaveBeenCalledWith('contract-address')
-      expect(mockedNftSupplyRepository.getNftSupplyByContractAddress).toHaveBeenCalledWith('contract-address')
+      expect(mockedNftSupplyRepository.getNftSupplyByResourceAndSessionId).toHaveBeenCalledWith(
+        'contract-address',
+        'session-123'
+      )
+      expect(mockedNftSupplyRepository.getNftSupplyByContractAndSessionId).toHaveBeenCalledWith(
+        'contract-address',
+        'session-123'
+      )
     })
 
     it('should throw ResourceNotFoundException if NFT supply is insufficient', async () => {
@@ -272,7 +284,7 @@ describe('ClaimNftOptions', () => {
       } as unknown as NftSupply
 
       mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
-      mockedNftSupplyRepository.getNftSupplyByResource.mockResolvedValue(insufficientSupply)
+      mockedNftSupplyRepository.getNftSupplyByResourceAndSessionId.mockResolvedValue(insufficientSupply)
 
       const payload: RequestSchemaT = {
         email: 'test@example.com',
@@ -301,7 +313,7 @@ describe('ClaimNftOptions', () => {
       } as unknown as Nft
 
       mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
-      mockedNftSupplyRepository.getNftSupplyByResource.mockResolvedValue(mockNftSupply)
+      mockedNftSupplyRepository.getNftSupplyByResourceAndSessionId.mockResolvedValue(mockNftSupply)
       mockedNftRepository.getNftByUserAndSessionId.mockResolvedValue(existingNft)
 
       const payload: RequestSchemaT = {
@@ -316,7 +328,7 @@ describe('ClaimNftOptions', () => {
 
     it('should return NFT options successfully when all conditions are met', async () => {
       mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
-      mockedNftSupplyRepository.getNftSupplyByResource.mockResolvedValue(mockNftSupply)
+      mockedNftSupplyRepository.getNftSupplyByResourceAndSessionId.mockResolvedValue(mockNftSupply)
       mockedNftRepository.getNftByUserAndSessionId.mockResolvedValue(null)
 
       const payload: RequestSchemaT = {
@@ -357,7 +369,7 @@ describe('ClaimNftOptions', () => {
       } as unknown as NftSupply
 
       mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
-      mockedNftSupplyRepository.getNftSupplyByResource.mockResolvedValue(edgeCaseSupply)
+      mockedNftSupplyRepository.getNftSupplyByResourceAndSessionId.mockResolvedValue(edgeCaseSupply)
 
       const payload: RequestSchemaT = {
         email: 'test@example.com',
@@ -376,7 +388,7 @@ describe('ClaimNftOptions', () => {
       } as unknown as NftSupply
 
       mockedUserRepository.getUserByEmail.mockResolvedValue(mockUser)
-      mockedNftSupplyRepository.getNftSupplyByResource.mockResolvedValue(invalidSupply)
+      mockedNftSupplyRepository.getNftSupplyByResourceAndSessionId.mockResolvedValue(invalidSupply)
 
       const payload: RequestSchemaT = {
         email: 'test@example.com',

--- a/apps/backend/src/api/embedded-wallets/use-cases/claim-nft-options/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/claim-nft-options/index.ts
@@ -65,9 +65,15 @@ export class ClaimNftOptions extends UseCaseBase implements IUseCaseHttp<Respons
     }
 
     // Get NFT Supply data
-    let nftSupply = await this.nftSupplyRepository.getNftSupplyByResource(validatedData.resource)
+    let nftSupply = await this.nftSupplyRepository.getNftSupplyByResourceAndSessionId(
+      validatedData.resource,
+      validatedData.session_id
+    )
     if (!nftSupply) {
-      nftSupply = await this.nftSupplyRepository.getNftSupplyByContractAddress(validatedData.resource)
+      nftSupply = await this.nftSupplyRepository.getNftSupplyByContractAndSessionId(
+        validatedData.resource,
+        validatedData.session_id
+      )
     }
 
     if (!nftSupply) {


### PR DESCRIPTION
### What

Fix supply search logic on claim NFT options

### Why

Fix a bug that was returning more than one result in supply search

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
