### PR TITLE
Feat(web): integrate organization transfer

### DIFF
--- a/apps/web/src/app/wallet/components/index.ts
+++ b/apps/web/src/app/wallet/components/index.ts
@@ -1,4 +1,5 @@
 export * from './confirm-transfer-drawer'
 export * from './empty-list'
+export * from './select-amount-transfer-drawer'
 export * from './view-nft-drawer'
 export * from './wallet-address-form'

--- a/apps/web/src/app/wallet/components/select-amount-transfer-drawer/index.tsx
+++ b/apps/web/src/app/wallet/components/select-amount-transfer-drawer/index.tsx
@@ -1,0 +1,116 @@
+import { Button, Text, Icon } from '@stellar/design-system'
+import { useEffect, useMemo } from 'react'
+import { UseFormReturn } from 'react-hook-form'
+
+import { formatNumber } from 'src/app/core/utils'
+import { Drawer, Form } from 'src/components/organisms'
+import { c } from 'src/interfaces/cms/useContent'
+
+import { TransferAmountFormValues } from './schema'
+
+type Props = {
+  isOpen: boolean
+  isTransferring: boolean
+  form: UseFormReturn<TransferAmountFormValues>
+  target: string
+  balance: number
+  onClose: () => void
+  onConfirm: (values: TransferAmountFormValues) => void
+}
+
+export const SelectAmountTransferDrawer = ({
+  isOpen,
+  isTransferring,
+  form,
+  target,
+  balance,
+  onClose,
+  onConfirm,
+}: Props) => {
+  const amount = form.watch('amount')
+  const isSubmitDisabled = useMemo(() => amount > balance || !amount, [amount, balance])
+
+  const inputDescription = `${c('selectAmountTransferDrawerInputDescription')} ${formatNumber(
+    balance,
+    'en-US',
+    Infinity,
+    2,
+    7
+  )} XLM`
+
+  const percentageButtons = [
+    { label: '‎ 25% ‎', value: 0.25 },
+    { label: '‎ 50% ‎', value: 0.5 },
+    { label: '‎ 75% ‎', value: 0.75 },
+    { label: '‎ Max ‎', value: 1 },
+  ]
+
+  useEffect(() => {
+    if (isOpen) form.setFocus('amount')
+  }, [isOpen, form])
+
+  return (
+    <Drawer
+      size="max-height"
+      closeButtonVariant="ghost"
+      isOpen={isOpen}
+      isLocked={isTransferring}
+      onClose={onClose}
+      hasCloseButton
+    >
+      <Form form={form} onSubmit={onConfirm}>
+        <div className="flex flex-col text-center items-center gap-4 p-6 mt-[61px]">
+          <div>
+            <Text as="span" size="xs" weight="medium" addlClassName="text-textSecondary">
+              {c('selectAmountTransferDrawerTitle')}
+            </Text>
+            <Text as="h2" size="lg" weight="semi-bold">
+              {target}
+            </Text>
+          </div>
+
+          <div className="flex flex-col gap-8 py-8 items-center">
+            <div className="flex flex-col gap-2">
+              <Form.AssetAmountInput name="amount" assetLabel="XLM" />
+
+              <Text as="span" size="sm" addlClassName="text-textSecondary">
+                {inputDescription}
+              </Text>
+            </div>
+
+            <div className="flex flex-row gap-2">
+              {percentageButtons.map(item => (
+                <Button
+                  key={item.label}
+                  variant="tertiary"
+                  size="md"
+                  disabled={balance * item.value === amount}
+                  onClick={e => {
+                    e.stopPropagation()
+                    form.setValue('amount', balance * item.value)
+                  }}
+                  isRounded
+                >
+                  {item.label}
+                </Button>
+              ))}
+            </div>
+          </div>
+
+          <Form.Submit
+            variant="secondary"
+            size="xl"
+            isLoading={isTransferring}
+            disabled={isSubmitDisabled}
+            icon={<Icon.HeartHand />}
+            iconPosition="left"
+            isRounded
+            isFullWidth
+          >
+            {c('selectAmountTransferDrawerSubmitText')}
+          </Form.Submit>
+        </div>
+      </Form>
+    </Drawer>
+  )
+}

--- a/apps/web/src/app/wallet/components/select-amount-transfer-drawer/schema.ts
+++ b/apps/web/src/app/wallet/components/select-amount-transfer-drawer/schema.ts
@@ -1,0 +1,8 @@
+import * as yup from 'yup'
+
+// Schema definition
+export const transferAmountFormSchema = yup.object({
+  amount: yup.number().required('Amount is required'),
+})
+
+export type TransferAmountFormValues = yup.InferType<typeof transferAmountFormSchema>

--- a/apps/web/src/app/wallet/hooks/use-handle-transfer-left-assets.ts
+++ b/apps/web/src/app/wallet/hooks/use-handle-transfer-left-assets.ts
@@ -1,4 +1,5 @@
 import { Icon } from '@stellar/design-system'
+import { useRouter } from '@tanstack/react-router'
 import { useEffect, useMemo } from 'react'
 
 import { modalService } from 'src/components/organisms/modal/provider'
@@ -6,6 +7,7 @@ import { a } from 'src/interfaces/cms/useAssets'
 import { c } from 'src/interfaces/cms/useContent'
 
 import { BannerOptions } from '../pages/home/template'
+import { WalletPagesPath } from '../routes/types'
 import { useTransferLeftAssetsStore } from '../store'
 
 type HandleTransferLeftAssetsProps = {
@@ -19,6 +21,7 @@ type HandleTransferLeftAssetsReturn = {
 export const useHandleTransferLeftAssets = ({
   enabled,
 }: HandleTransferLeftAssetsProps): HandleTransferLeftAssetsReturn => {
+  const router = useRouter()
   const { isFirstOpen: isTransferLeftAssetsFirstOpen, setIsFirstOpen: setIsTransferLeftAssetsFirstOpen } =
     useTransferLeftAssetsStore()
 
@@ -36,11 +39,13 @@ export const useHandleTransferLeftAssets = ({
         title: c('transferLeftAssetsBannerButtonTitle'),
         icon: Icon.ArrowRight({ className: 'text-whitish' }),
         onClick: () => {
-          // TODO: navigate to left-assets page
+          router.navigate({
+            to: WalletPagesPath.LEFT_ASSETS,
+          })
         },
       },
     }),
-    []
+    [router]
   )
 
   const shouldOpenTransferLeftAssetsModal = useMemo(
@@ -73,7 +78,10 @@ export const useHandleTransferLeftAssets = ({
             isRounded: true,
             icon: Icon.ArrowRight({ className: 'text-whitish' }),
             onClick: () => {
-              // TODO: navigate to left-assets page
+              router.navigate({
+                to: WalletPagesPath.LEFT_ASSETS,
+              })
+              modalService.close()
             },
           },
         },
@@ -81,7 +89,7 @@ export const useHandleTransferLeftAssets = ({
         onClose: () => setIsTransferLeftAssetsFirstOpen(false),
       })
     }
-  }, [setIsTransferLeftAssetsFirstOpen, shouldOpenTransferLeftAssetsModal])
+  }, [router, setIsTransferLeftAssetsFirstOpen, shouldOpenTransferLeftAssetsModal])
 
   return {
     banner: shouldReturnBanner ? banner : undefined,

--- a/apps/web/src/components/organisms/form/fields/asset-amount-input.tsx
+++ b/apps/web/src/components/organisms/form/fields/asset-amount-input.tsx
@@ -1,0 +1,168 @@
+import { Text, Heading } from '@stellar/design-system'
+import { useRef, useState, useEffect, useCallback, forwardRef, useImperativeHandle } from 'react'
+import { Controller, useFormContext, ControllerRenderProps, FieldValues, FormState } from 'react-hook-form'
+
+type Props = {
+  name: string
+  assetLabel: string
+  placeholder?: string
+  decimals?: number
+  maxDigits?: number
+}
+
+const DEFAULT_DECIMALS = 2
+
+const AssetAmountInputField = forwardRef<
+  HTMLInputElement,
+  {
+    name: string
+    field: ControllerRenderProps<FieldValues, string>
+    formState: FormState<FieldValues>
+    assetLabel: string
+    placeholder: string
+    decimals: number
+    maxDigits: number
+  }
+>(({ name, field, formState, assetLabel, placeholder, decimals, maxDigits }, ref) => {
+  const [rawDigits, setRawDigits] = useState('')
+  const [isFocused, setIsFocused] = useState(false)
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  useImperativeHandle(ref, () => inputRef.current as HTMLInputElement)
+
+  const formatter = new Intl.NumberFormat('en-US', {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: decimals,
+  })
+
+  const filterOnlyDigits = useCallback(
+    (value: string | number) => {
+      if (!value) return ''
+      let onlyDigits = value.toString().replace(/\D/g, '')
+      if (onlyDigits.length > maxDigits) {
+        onlyDigits = onlyDigits.slice(0, maxDigits)
+      }
+      return onlyDigits
+    },
+    [maxDigits]
+  )
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const onlyDigits = filterOnlyDigits(e.target.value)
+    setRawDigits(onlyDigits)
+
+    if (!onlyDigits) {
+      field.onChange('')
+      return
+    }
+
+    const scaled = Number(onlyDigits) / Math.pow(10, decimals)
+    field.onChange(scaled)
+  }
+
+  useEffect(() => {
+    // only sync when form value changes externally (not while typing)
+    if (!isFocused) {
+      if (field.value == null || field.value === '') {
+        setRawDigits('')
+        return
+      }
+
+      const scaled = Number(field.value)
+      const digits = Math.round(scaled * Math.pow(10, decimals)).toString()
+      setRawDigits(digits)
+    }
+  }, [field.value, decimals, isFocused])
+
+  useEffect(() => {
+    const input = inputRef.current
+    if (!input) return
+
+    const handleFocus = () => setIsFocused(true)
+    const handleBlur = () => setIsFocused(false)
+
+    input.addEventListener('focus', handleFocus)
+    input.addEventListener('blur', handleBlur)
+
+    return () => {
+      input.removeEventListener('focus', handleFocus)
+      input.removeEventListener('blur', handleBlur)
+    }
+  }, [])
+
+  const formattedValue = field.value && !isNaN(Number(field.value)) ? formatter.format(Number(field.value)) : ''
+  const error = formState.errors[name]?.message as string | undefined
+
+  return (
+    <div>
+      <div className="flex items-baseline justify-center gap-1 cursor-text" onClick={() => inputRef.current?.focus()}>
+        {/* Hidden input for real typing */}
+        <input
+          ref={inputRef}
+          value={rawDigits}
+          onChange={handleChange}
+          onFocus={() => setIsFocused(true)}
+          onBlur={() => setIsFocused(false)}
+          inputMode="numeric"
+          type="text"
+          readOnly={false}
+          className="absolute left-[-9999px] w-0 h-0 border-0 p-0 m-0 outline-none"
+          aria-hidden="true"
+        />
+
+        {/* Visual display */}
+        <span className="relative bg-transparent text-right tracking-tight">
+          <Heading addlClassName="text-text" as="h1" size="xs" weight="semi-bold">
+            {formattedValue || placeholder}
+          </Heading>
+
+          {isFocused && (
+            <span className="absolute -right-[0.5px] top-1/2 -translate-y-1/2 h-[1.5em] w-[1px] bg-current animate-blink" />
+          )}
+        </span>
+
+        {/* Asset label */}
+        <Text addlClassName="text-textSecondary" size="md" weight="medium" as="span">
+          {assetLabel}
+        </Text>
+      </div>
+
+      {error && (
+        <div className="text-left text-error mt-1">
+          <Text as="p" size="sm">
+            {error}
+          </Text>
+        </div>
+      )}
+    </div>
+  )
+})
+
+export const AssetAmountInput = ({
+  name,
+  assetLabel,
+  placeholder = '0.00',
+  decimals = DEFAULT_DECIMALS,
+  maxDigits = 18,
+}: Props) => {
+  const { control, formState } = useFormContext()
+
+  return (
+    <Controller
+      name={name}
+      control={control}
+      render={({ field }) => (
+        <AssetAmountInputField
+          ref={field.ref}
+          name={name}
+          field={field}
+          formState={formState}
+          assetLabel={assetLabel}
+          placeholder={placeholder}
+          decimals={decimals}
+          maxDigits={maxDigits}
+        />
+      )}
+    />
+  )
+}

--- a/apps/web/src/components/organisms/form/form.test.tsx
+++ b/apps/web/src/components/organisms/form/form.test.tsx
@@ -30,6 +30,7 @@ describe('Form', () => {
   })
 
   it('attaches field components as static properties', () => {
+    expect(Form.AssetAmountInput).toBeDefined()
     expect(Form.Input).toBeDefined()
     expect(Form.Checkbox).toBeDefined()
     expect(Form.Radio).toBeDefined()

--- a/apps/web/src/components/organisms/form/index.tsx
+++ b/apps/web/src/components/organisms/form/index.tsx
@@ -1,6 +1,7 @@
 import { FieldValues, FormProvider as RHFFormProvider, useForm } from 'react-hook-form'
 
 // Import fields
+import { AssetAmountInput } from './fields/asset-amount-input'
 import { Checkbox } from './fields/checkbox'
 import { Input } from './fields/input'
 import { Radio } from './fields/radio'
@@ -28,6 +29,7 @@ function BaseForm<T extends Record<string, unknown>>({ form, onSubmit, children 
 
 // Attach fields as static properties
 export const Form = Object.assign(BaseForm, {
+  AssetAmountInput,
   Input,
   Checkbox,
   Radio,

--- a/apps/web/src/config/content.example.json
+++ b/apps/web/src/config/content.example.json
@@ -131,5 +131,8 @@
   "confirmTransferDrawerTitle": "Before you transfer",
   "confirmTransferDrawerDescription1": "Please note that do not transfer to accounts that",
   "confirmTransferDrawerDescription2": "require a Stellar memo, including exchanges",
-  "confirmTransferDrawerDescription3": "like Coinbase. You could lose funds."
+  "confirmTransferDrawerDescription3": "like Coinbase. You could lose funds.",
+  "selectAmountTransferDrawerTitle": "Send to",
+  "selectAmountTransferDrawerInputDescription": "Balance:",
+  "selectAmountTransferDrawerSubmitText": "Transfer"
 }

--- a/apps/web/src/config/theme/css-variables.css
+++ b/apps/web/src/config/theme/css-variables.css
@@ -19,6 +19,7 @@
   --color-whitish: #FFFFFF;
   --color-blackish: #000000;
   --color-muted: #f6f6f6;
+  --color-error: #cd2b31;
   --color-success: #30A46C;
   --color-danger: #ff3636;
   --color-warning: #FFB224;

--- a/apps/web/src/config/theme/theme.ts
+++ b/apps/web/src/config/theme/theme.ts
@@ -25,6 +25,7 @@ export const THEME_STYLES = {
         whitish: 'var(--color-whitish)',
         blackish: 'var(--color-blackish)',
         muted: 'var(--color-muted)',
+        error: 'var(--color-error)',
         success: 'var(--color-success)',
         danger: 'var(--color-danger)',
         warning: 'var(--color-warning)',
@@ -75,9 +76,14 @@ export const THEME_STYLES = {
           '0%': { backgroundPosition: '0% 0%' },
           '100%': { backgroundPosition: '100% 0%' },
         },
+        blink: {
+          '0%, 49%': { opacity: 1 },
+          '50%, 100%': { opacity: 0 },
+        },
       },
       animation: {
         'background-move': 'background-move 60s linear infinite alternate',
+        blink: 'blink 1s step-end infinite',
       },
     },
   },


### PR DESCRIPTION
### What

- Creates `asset-amount-input` under `form` component
     - Custom input used exclusively to manage `assetAmount`
- Creates `select-amount-transfer-drawer` used to transfer to `organizations`
- Integrates organization transfer   
  
### Why

- Enables left assets organization transfer

### Visual

| |
|--------|
| <video src="https://github.com/user-attachments/assets/58c211c6-49e0-4e78-a659-e142f83d8822" /> | 




### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
