### PR TITLE
Feat(web): disable left-assets banner once empty assets

### DIFF
--- a/apps/web/src/app/wallet/domain/use-cases/get-wallet/types.ts
+++ b/apps/web/src/app/wallet/domain/use-cases/get-wallet/types.ts
@@ -1,18 +1,3 @@
-import { WalletStatus } from 'src/app/auth/domain/models/user'
+import { GetWalletResult as ServiceGetWalletResult } from 'src/app/wallet/services/wallet/types'
 
-export type GetWalletResult = {
-  status: WalletStatus
-  address: string
-  email: string
-  balance: number
-  is_airdrop_available: boolean
-  is_gift_available: boolean
-  swags?: {
-    code: string
-    name?: string
-    description: string
-    imageUrl?: string
-    assetCode: string
-    status: 'unclaimed' | 'claimed'
-  }[]
-}
+export type GetWalletResult = ServiceGetWalletResult['data']

--- a/apps/web/src/app/wallet/pages/home/index.tsx
+++ b/apps/web/src/app/wallet/pages/home/index.tsx
@@ -31,6 +31,9 @@ export const Home = () => {
   })
   const walletData = getWallet.data
   const isUserAirdropAvailable = walletData ? walletData.is_airdrop_available : false
+  const pendingLeftAssets = walletData?.token_balances
+    ? walletData.token_balances.every(t => t.balance === 0) && walletData.balance === 0
+    : false
 
   // Handle airdrop
   const { banner: airdropBanner } = useHandleAirdrop({
@@ -39,7 +42,7 @@ export const Home = () => {
 
   // Handle left transfer assets
   const { banner: transferLeftAssetsBanner } = useHandleTransferLeftAssets({
-    enabled: isTransferLeftAssetsActive,
+    enabled: isTransferLeftAssetsActive && !getWallet.isLoading && !pendingLeftAssets,
   })
 
   // Handle behind the scenes

--- a/apps/web/src/app/wallet/services/wallet/types.ts
+++ b/apps/web/src/app/wallet/services/wallet/types.ts
@@ -23,6 +23,7 @@ export type GetWalletResult = IHTTPResponse<{
   address: string
   email: string
   balance: number
+  token_balances?: { contract_address: string; balance: number; type: 'nft' | 'asset' }[]
   is_airdrop_available: boolean
   is_gift_available: boolean
   swags?: {


### PR DESCRIPTION
### What

- Disables `left-assets` banner once the user has empty assets

### Why

- `left-assets` flow only makes sense if the user still has pending assets

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
