### PR TITLE
Hotfix: isolate prod deployment on workflows

### DIFF
--- a/.github/workflows/backend.deploy.yaml
+++ b/.github/workflows/backend.deploy.yaml
@@ -44,8 +44,8 @@ jobs:
 
   deploy-prod-mainnet:
     name: Deploy to Heroku (Production Mainnet)
-    needs: [set-outputs, deploy-staging-testnet]
-    if: needs.deploy-staging-testnet.result == 'success' && needs.set-outputs.result == 'success' && needs.set-outputs.outputs.environment == 'Production-Mainnet'
+    needs: [set-outputs, build, code-quality]
+    if: needs.code-quality.result == 'success' && needs.build.result == 'success' && needs.set-outputs.result == 'success' && needs.set-outputs.outputs.environment == 'Production-Mainnet'
     uses: ./.github/workflows/backend.deploy-heroku.yaml
     with:
       environment: ${{ needs.set-outputs.outputs.environment }}

--- a/.github/workflows/web.deploy.yaml
+++ b/.github/workflows/web.deploy.yaml
@@ -25,8 +25,8 @@ jobs:
     needs: [set-outputs]
     uses: ./.github/workflows/web.build.yaml
     secrets:
-      APP_ASSETS_URL: ${{ secrets.WEB_APP_ASSETS_URL }}
-      APP_CONTENT_URL: ${{ secrets.WEB_APP_CONTENT_URL }}
+      APP_ASSETS_URL: ${{ needs.set-outputs.outputs.environment == 'Production-Mainnet' && secrets.WEB_PROD_APP_ASSETS_URL || secrets.WEB_STAGING_APP_ASSETS_URL }}
+      APP_CONTENT_URL: ${{ needs.set-outputs.outputs.environment == 'Production-Mainnet' && secrets.WEB_PROD_APP_CONTENT_URL || secrets.WEB_STAGING_APP_CONTENT_URL }}
       SENTRY_ORG: ${{ secrets.SENTRY_ORG }}
       SENTRY_PROJECT_WEB: ${{ secrets.SENTRY_PROJECT_WEB }}
       SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -50,8 +50,8 @@ jobs:
 
   deploy-prod-mainnet:
     name: Deploy to Heroku (Production Mainnet)
-    needs: [set-outputs, deploy-staging-testnet]
-    if: needs.deploy-staging-testnet.result == 'success' && needs.set-outputs.result == 'success' && needs.set-outputs.outputs.environment == 'Production-Mainnet'
+    needs: [set-outputs, build, code-quality]
+    if: needs.code-quality.result == 'success' && needs.build.result == 'success' && needs.set-outputs.result == 'success' && needs.set-outputs.outputs.environment == 'Production-Mainnet'
     uses: ./.github/workflows/web.deploy-heroku.yaml
     with:
       environment: ${{ needs.set-outputs.outputs.environment }}


### PR DESCRIPTION
### What

- Isolates prod deployment on workflows

### Why

- Necessary to reduce dependency on Staging deployments

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
