### PR TITLE
Feature(backend): Implement account creation API

### DIFF
--- a/apps/backend/src/api/core/entities/user/model.ts
+++ b/apps/backend/src/api/core/entities/user/model.ts
@@ -27,6 +27,12 @@ export class User extends ModelBase {
   })
   contractAddress?: string
 
+  @Column({
+    type: 'varchar',
+    nullable: true,
+  })
+  createdAccountAddress?: string
+
   @OneToMany(() => Passkey, passkey => passkey.user)
   passkeys: Passkey[]
 

--- a/apps/backend/src/api/core/migrations/1756300000000-create-created-account-table.ts
+++ b/apps/backend/src/api/core/migrations/1756300000000-create-created-account-table.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddCreatedAccountAddressToUser1756300000000 implements MigrationInterface {
+  readonly name: string = 'AddCreatedAccountAddressToUser1756300000000'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" ADD "created_account_address" character varying`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "user" DROP COLUMN "created_account_address"`)
+  }
+}

--- a/apps/backend/src/api/embedded-wallets/constants/messages.ts
+++ b/apps/backend/src/api/embedded-wallets/constants/messages.ts
@@ -41,4 +41,7 @@ export const messages = {
   USER_SWAG_ALREADY_CLAIMED_OR_NOT_AVAILABLE:
     'The swag you are trying to claim has already been claimed or is not available',
   UNABLE_TO_EXECUTE_ROTATE_SIGNER: 'Unable to execute rotate signer transaction',
+  USER_ALREADY_CREATED_ACCOUNT: 'You have already created an account. Only one account per user is allowed',
+  ACCOUNT_ALREADY_EXISTS_ON_NETWORK: 'Account already exists on the Stellar network',
+  UNABLE_TO_SUBMIT_ACCOUNT_CREATION_TRANSACTION: 'Unable to submit account creation transaction',
 }

--- a/apps/backend/src/api/embedded-wallets/constants/messages.ts
+++ b/apps/backend/src/api/embedded-wallets/constants/messages.ts
@@ -41,7 +41,8 @@ export const messages = {
   USER_SWAG_ALREADY_CLAIMED_OR_NOT_AVAILABLE:
     'The swag you are trying to claim has already been claimed or is not available',
   UNABLE_TO_EXECUTE_ROTATE_SIGNER: 'Unable to execute rotate signer transaction',
-  USER_ALREADY_CREATED_ACCOUNT: 'You have already created an account. Only one account per user is allowed',
+  USER_ALREADY_CREATED_ACCOUNT:
+    'You have already created an account. This wallet only sponsors the creation of one Stellar account per user',
   ACCOUNT_ALREADY_EXISTS_ON_NETWORK: 'Account already exists on the Stellar network',
   UNABLE_TO_SUBMIT_ACCOUNT_CREATION_TRANSACTION: 'Unable to submit account creation transaction',
 }

--- a/apps/backend/src/api/embedded-wallets/routes.ts
+++ b/apps/backend/src/api/embedded-wallets/routes.ts
@@ -6,6 +6,7 @@ import { AirdropComplete, endpoint as AirdropCompleteEndpoint } from './use-case
 import { AirdropOptions, endpoint as AirdropOptionsEndpoint } from './use-cases/airdrop-options'
 import { ClaimNft, endpoint as ClaimNftEndpoint } from './use-cases/claim-nft'
 import { ClaimNftOptions, endpoint as ClaimNftOptionsEndpoint } from './use-cases/claim-nft-options'
+import { CreateAccount, endpoint as CreateAccountEndpoint } from './use-cases/create-account'
 import { CreateWallet, endpoint as CreateWalletEndpoint } from './use-cases/create-wallet'
 import { CreateWalletOptions, endpoint as CreateWalletOptionsEndpoint } from './use-cases/create-wallet-options'
 import { GenerateRecoveryLink, endpoint as GenerateRecoveryLinkEndpoint } from './use-cases/generate-recovery-link'
@@ -29,6 +30,7 @@ const router = Router()
 router.get(`${GetInvitationInfoEndpoint}`, async (req, res) => GetInvitationInfo.init().executeHttp(req, res))
 router.get(`${CreateWalletOptionsEndpoint}`, async (req, res) => CreateWalletOptions.init().executeHttp(req, res))
 router.post(`${CreateWalletEndpoint}`, async (req, res) => CreateWallet.init().executeHttp(req, res))
+router.post(`${CreateAccountEndpoint}`, authentication, async (req, res) => CreateAccount.init().executeHttp(req, res))
 router.get(`${LogInOptionsEndpoint}`, async (req, res) => LogInOptions.init().executeHttp(req, res))
 router.post(`${LogInEndpoint}`, async (req, res) => LogIn.init().executeHttp(req, res))
 router.get(`${GetWalletEndpoint}`, authentication, async (req, res) => GetWallet.init().executeHttp(req, res))

--- a/apps/backend/src/api/embedded-wallets/use-cases/create-account/index.docs.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/create-account/index.docs.ts
@@ -9,7 +9,7 @@ export const CreateAccountDocs = {
   '/embedded-wallets/create-account': {
     post: {
       summary: 'Create Stellar Account',
-      description: 'Creates a new Stellar account. Each user can create only one account.',
+      description: 'Creates a new Stellar (G) account. Each user can create only one account.',
       tags: [Tags.EMBEDDED_WALLETS],
       security: [{ bearerAuth: [] }],
       requestBody: {

--- a/apps/backend/src/api/embedded-wallets/use-cases/create-account/index.docs.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/create-account/index.docs.ts
@@ -1,0 +1,39 @@
+import { badRequest, conflict, notFound, unauthorized } from 'api/core/utils/docs/error.docs'
+import { Tags } from 'api/core/utils/docs/tags'
+import { HttpStatusCodes } from 'api/core/utils/http/status-code'
+import { zodToSchema } from 'api/core/utils/zod'
+
+import { RequestSchema, ResponseSchema } from './types'
+
+export const CreateAccountDocs = {
+  '/embedded-wallets/create-account': {
+    post: {
+      summary: 'Create Stellar Account',
+      description: 'Creates a new Stellar account. Each user can create only one account.',
+      tags: [Tags.EMBEDDED_WALLETS],
+      security: [{ bearerAuth: [] }],
+      requestBody: {
+        required: true,
+        content: {
+          'application/json': {
+            schema: zodToSchema(RequestSchema),
+          },
+        },
+      },
+      responses: {
+        [HttpStatusCodes.OK]: {
+          description: 'Account created successfully',
+          content: {
+            'application/json': {
+              schema: zodToSchema(ResponseSchema),
+            },
+          },
+        },
+        ...unauthorized,
+        ...badRequest,
+        ...conflict,
+        ...notFound,
+      },
+    },
+  },
+}

--- a/apps/backend/src/api/embedded-wallets/use-cases/create-account/index.test.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/create-account/index.test.ts
@@ -1,0 +1,195 @@
+import { rpc } from '@stellar/stellar-sdk'
+
+import { userFactory } from 'api/core/entities/user/factory'
+import { User } from 'api/core/entities/user/types'
+import { mockUserRepository } from 'api/core/services/user/mocks'
+import { HttpStatusCodes } from 'api/core/utils/http/status-code'
+import { ResourceConflictedException } from 'errors/exceptions/resource-conflict'
+import { ResourceNotFoundException } from 'errors/exceptions/resource-not-found'
+import { UnauthorizedException } from 'errors/exceptions/unauthorized'
+import { mockSorobanService } from 'interfaces/soroban/mock'
+import { mockWalletBackend } from 'interfaces/wallet-backend/mock'
+
+import { CreateAccount, endpoint } from './index'
+
+const email = 'test-email@example.com'
+const testAddress = 'GCD2KGJDSC6W4WOEZYUVUWHSDLC4NKG6GFW7GP6NYE2PCE2V2XN7UOT3'
+
+const user = userFactory({
+  email,
+  userId: 'test-user-id',
+})
+
+const walletBackendResponse = {
+  transaction:
+    'AAAAAgAAAAAuSqBGjfA/7LAYylzmDmG71S7+osSfehew6Q0UwqW4MgX14QAAAAwSAAAAIwAAAAEAAAAAAAAAAAAAAABot0i8AAAAAAAAAAEAAAABAAAAAIij+uaAFU+LDP4Q/cWyBTvZoWdaz1ctuzgQmdkf1UT6AAAAAAAAAAAUL/P6LZCom2KvC5uhnZqTK21PvwmVHsNLh0Fg/q16TgAAAAAAmJaAAAAAAAAAAALCpbgyAAAAQI93XilptmWHkWVjzlDbL4B64KSt/vNaNtvH5z3IlJ6kdw8ApzARK2QLJJSI+ZZV6Xz5J9R73wkUJpm/3xw6YgYf1UT6AAAAQKoKe/BfTHQk01aWD8EvNoHSdm3U2MSuhnh9tPfxSKwpqZ6dgGQWVOkLrAQ9Ykf5YqT5oZxKucKYc83uXRYtMQw=',
+  networkPassphrase: 'Test SDF Network ; September 2015',
+}
+
+const basePayload = {
+  email,
+  address: testAddress,
+}
+
+const mockedUserRepository = mockUserRepository()
+const mockedWalletBackend = mockWalletBackend()
+const mockedSorobanService = mockSorobanService()
+
+let useCase: CreateAccount
+
+describe('CreateAccount', () => {
+  it('should export endpoint', () => {
+    expect(endpoint).toBe('/create-account')
+  })
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    useCase = new CreateAccount(mockedUserRepository, mockedWalletBackend, mockedSorobanService)
+  })
+
+  describe('handle', () => {
+    it('should create an account successfully', async () => {
+      const testUser = { ...user, createdAccountAddress: undefined } as User
+      mockedUserRepository.getUserByEmail.mockResolvedValue(testUser)
+      mockedWalletBackend.createSponsoredAccount.mockResolvedValue(walletBackendResponse)
+      mockedSorobanService.sendTransaction.mockResolvedValue({
+        status: rpc.Api.GetTransactionStatus.SUCCESS,
+        hash: 'test-transaction-hash',
+      } as unknown as rpc.Api.GetSuccessfulTransactionResponse)
+      mockedUserRepository.saveUser.mockResolvedValue(testUser)
+
+      const result = await useCase.handle(basePayload)
+
+      expect(result).toEqual({
+        data: {
+          address: testAddress,
+          transaction: walletBackendResponse.transaction,
+          networkPassphrase: walletBackendResponse.networkPassphrase,
+        },
+        message: 'Account created successfully',
+      })
+
+      expect(mockedWalletBackend.createSponsoredAccount).toHaveBeenCalledWith(testAddress)
+      expect(mockedSorobanService.sendTransaction).toHaveBeenCalledWith(walletBackendResponse.transaction)
+      expect(mockedUserRepository.saveUser).toHaveBeenCalledWith({
+        ...testUser,
+        createdAccountAddress: testAddress,
+      })
+    })
+
+    it('should throw UnauthorizedException when email is missing', async () => {
+      const payload = { ...basePayload, email: '' }
+
+      await expect(useCase.handle(payload)).rejects.toBeInstanceOf(UnauthorizedException)
+    })
+
+    it('should throw validation error when address is empty', async () => {
+      const payload = { ...basePayload, address: '' }
+
+      await expect(useCase.handle(payload)).rejects.toThrow('The payload has validation errors')
+    })
+
+    it('should throw validation error when address does not start with G', async () => {
+      const payload = { ...basePayload, address: 'CABC123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ123456789ABCDEF' }
+
+      await expect(useCase.handle(payload)).rejects.toThrow('The payload has validation errors')
+    })
+
+    it('should throw ResourceNotFoundException when user is not found', async () => {
+      mockedUserRepository.getUserByEmail.mockResolvedValue(null)
+
+      await expect(useCase.handle(basePayload)).rejects.toBeInstanceOf(ResourceNotFoundException)
+    })
+
+    it('should throw ResourceConflictedException when user already created an account', async () => {
+      const userWithCreatedAccount = { ...user, createdAccountAddress: 'EXISTING_ADDRESS' } as User
+      mockedUserRepository.getUserByEmail.mockResolvedValue(userWithCreatedAccount)
+
+      await expect(useCase.handle(basePayload)).rejects.toBeInstanceOf(ResourceConflictedException)
+    })
+
+    it('should throw ResourceConflictedException when account already exists on network', async () => {
+      const testUser = { ...user, createdAccountAddress: undefined } as User
+      mockedUserRepository.getUserByEmail.mockResolvedValue(testUser)
+
+      const walletBackendError = {
+        isAxiosError: true,
+        response: { status: HttpStatusCodes.CONFLICT },
+        message: 'Conflict',
+      }
+      mockedWalletBackend.createSponsoredAccount.mockRejectedValue(walletBackendError)
+
+      await expect(useCase.handle(basePayload)).rejects.toBeInstanceOf(ResourceConflictedException)
+      await expect(useCase.handle(basePayload)).rejects.toThrow('The parameters conflicted with an existing resource')
+
+      expect(mockedWalletBackend.createSponsoredAccount).toHaveBeenCalledWith(testAddress)
+      expect(mockedSorobanService.sendTransaction).not.toHaveBeenCalled()
+      expect(mockedUserRepository.saveUser).not.toHaveBeenCalled()
+    })
+
+    it('should throw generic error when wallet-backend fails with non-409 error', async () => {
+      const testUser = { ...user, createdAccountAddress: undefined } as User
+      mockedUserRepository.getUserByEmail.mockResolvedValue(testUser)
+
+      const walletBackendError = {
+        isAxiosError: true,
+        response: { status: HttpStatusCodes.INTERNAL_SERVER_ERROR },
+        message: 'Server error',
+      }
+      mockedWalletBackend.createSponsoredAccount.mockRejectedValue(walletBackendError)
+
+      await expect(useCase.handle(basePayload)).rejects.toThrow('Server error')
+
+      expect(mockedWalletBackend.createSponsoredAccount).toHaveBeenCalledWith(testAddress)
+      expect(mockedSorobanService.sendTransaction).not.toHaveBeenCalled()
+      expect(mockedUserRepository.saveUser).not.toHaveBeenCalled()
+    })
+
+    it('should throw ResourceNotFoundException when transaction submission fails', async () => {
+      const testUser = { ...user, createdAccountAddress: undefined } as User
+      mockedUserRepository.getUserByEmail.mockResolvedValue(testUser)
+      mockedWalletBackend.createSponsoredAccount.mockResolvedValue(walletBackendResponse)
+      mockedSorobanService.sendTransaction.mockResolvedValue({
+        status: rpc.Api.GetTransactionStatus.FAILED,
+        hash: 'test-transaction-hash',
+      } as unknown as rpc.Api.GetSuccessfulTransactionResponse)
+
+      await expect(useCase.handle(basePayload)).rejects.toBeInstanceOf(ResourceNotFoundException)
+
+      expect(mockedWalletBackend.createSponsoredAccount).toHaveBeenCalledWith(testAddress)
+      expect(mockedSorobanService.sendTransaction).toHaveBeenCalledWith(walletBackendResponse.transaction)
+      expect(mockedUserRepository.saveUser).not.toHaveBeenCalled()
+    })
+
+    it('should throw ResourceNotFoundException when transaction response is null', async () => {
+      const testUser = { ...user, createdAccountAddress: undefined } as User
+      mockedUserRepository.getUserByEmail.mockResolvedValue(testUser)
+      mockedWalletBackend.createSponsoredAccount.mockResolvedValue(walletBackendResponse)
+      mockedSorobanService.sendTransaction.mockResolvedValue(
+        null as unknown as rpc.Api.GetSuccessfulTransactionResponse
+      )
+
+      await expect(useCase.handle(basePayload)).rejects.toBeInstanceOf(ResourceNotFoundException)
+
+      expect(mockedWalletBackend.createSponsoredAccount).toHaveBeenCalledWith(testAddress)
+      expect(mockedSorobanService.sendTransaction).toHaveBeenCalledWith(walletBackendResponse.transaction)
+      expect(mockedUserRepository.saveUser).not.toHaveBeenCalled()
+    })
+
+    it('should throw ResourceNotFoundException when transaction status is NOT_FOUND', async () => {
+      const testUser = { ...user, createdAccountAddress: undefined } as User
+      mockedUserRepository.getUserByEmail.mockResolvedValue(testUser)
+      mockedWalletBackend.createSponsoredAccount.mockResolvedValue(walletBackendResponse)
+      mockedSorobanService.sendTransaction.mockResolvedValue({
+        status: rpc.Api.GetTransactionStatus.NOT_FOUND,
+        hash: 'test-transaction-hash',
+      } as unknown as rpc.Api.GetSuccessfulTransactionResponse)
+
+      await expect(useCase.handle(basePayload)).rejects.toBeInstanceOf(ResourceNotFoundException)
+
+      expect(mockedWalletBackend.createSponsoredAccount).toHaveBeenCalledWith(testAddress)
+      expect(mockedSorobanService.sendTransaction).toHaveBeenCalledWith(walletBackendResponse.transaction)
+      expect(mockedUserRepository.saveUser).not.toHaveBeenCalled()
+    })
+  })
+})

--- a/apps/backend/src/api/embedded-wallets/use-cases/create-account/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/create-account/index.ts
@@ -1,0 +1,101 @@
+import { rpc } from '@stellar/stellar-sdk'
+import axios from 'axios'
+import { Request, Response } from 'express'
+
+import { UserRepositoryType } from 'api/core/entities/user/types'
+import { UseCaseBase } from 'api/core/framework/use-case/base'
+import { IUseCaseHttp } from 'api/core/framework/use-case/http'
+import UserRepository from 'api/core/services/user'
+import { HttpStatusCodes } from 'api/core/utils/http/status-code'
+import { messages } from 'api/embedded-wallets/constants/messages'
+import { ResourceConflictedException } from 'errors/exceptions/resource-conflict'
+import { ResourceNotFoundException } from 'errors/exceptions/resource-not-found'
+import { UnauthorizedException } from 'errors/exceptions/unauthorized'
+import SorobanService from 'interfaces/soroban'
+import { ISorobanService } from 'interfaces/soroban/types'
+import WalletBackend from 'interfaces/wallet-backend'
+import { WalletBackendType } from 'interfaces/wallet-backend/types'
+
+import { RequestSchema, RequestSchemaT, ResponseSchemaT } from './types'
+
+const endpoint = '/create-account'
+
+export class CreateAccount extends UseCaseBase implements IUseCaseHttp<ResponseSchemaT> {
+  private userRepository: UserRepositoryType
+  private walletBackend: WalletBackendType
+  private sorobanService: ISorobanService
+
+  constructor(
+    userRepository?: UserRepositoryType,
+    walletBackend?: WalletBackendType,
+    sorobanService?: ISorobanService
+  ) {
+    super()
+    this.userRepository = userRepository || UserRepository.getInstance()
+    this.walletBackend = walletBackend || WalletBackend.getInstance()
+    this.sorobanService = sorobanService || SorobanService.getInstance()
+  }
+
+  async executeHttp(request: Request, response: Response<ResponseSchemaT>) {
+    const email = request.userData?.email
+
+    if (!email) {
+      throw new UnauthorizedException(messages.NOT_AUTHORIZED)
+    }
+
+    const payload = {
+      ...request.body,
+      email,
+    }
+
+    const result = await this.handle(payload)
+    return response.status(HttpStatusCodes.OK).json(result)
+  }
+
+  async handle(payload: RequestSchemaT & { email: string }): Promise<ResponseSchemaT> {
+    if (!payload.email) {
+      throw new UnauthorizedException(messages.NOT_AUTHORIZED)
+    }
+
+    const validatedData = this.validate(payload, RequestSchema)
+
+    const user = await this.userRepository.getUserByEmail(payload.email)
+    if (!user) {
+      throw new ResourceNotFoundException(messages.USER_NOT_FOUND_BY_EMAIL)
+    }
+
+    if (user.createdAccountAddress) {
+      throw new ResourceConflictedException(messages.USER_ALREADY_CREATED_ACCOUNT)
+    }
+
+    let walletResponse
+    try {
+      walletResponse = await this.walletBackend.createSponsoredAccount(validatedData.address)
+    } catch (error) {
+      if (axios.isAxiosError(error) && error.response?.status === HttpStatusCodes.CONFLICT) {
+        throw new ResourceConflictedException(messages.ACCOUNT_ALREADY_EXISTS_ON_NETWORK)
+      }
+      throw error
+    }
+
+    const txResponse = await this.sorobanService.sendTransaction(walletResponse.transaction)
+
+    if (!txResponse || txResponse.status !== rpc.Api.GetTransactionStatus.SUCCESS) {
+      throw new ResourceNotFoundException(messages.UNABLE_TO_SUBMIT_ACCOUNT_CREATION_TRANSACTION)
+    }
+
+    user.createdAccountAddress = validatedData.address
+    await this.userRepository.saveUser(user)
+
+    return {
+      data: {
+        address: validatedData.address,
+        transaction: walletResponse.transaction,
+        networkPassphrase: walletResponse.networkPassphrase,
+      },
+      message: 'Account created successfully',
+    }
+  }
+}
+
+export { endpoint }

--- a/apps/backend/src/api/embedded-wallets/use-cases/create-account/types.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/create-account/types.ts
@@ -1,0 +1,29 @@
+import { StrKey } from '@stellar/stellar-sdk'
+import { z } from 'zod'
+
+import { createResponseSchema } from 'api/core/framework/use-case/base'
+
+export const RequestSchema = z.object({
+  address: z
+    .string()
+    .min(1, 'Address is required')
+    .refine(value => {
+      try {
+        return StrKey.isValidEd25519PublicKey(value)
+      } catch {
+        return false
+      }
+    }, 'Must be a valid Stellar public key'),
+})
+
+export type RequestSchemaT = z.infer<typeof RequestSchema>
+
+export const ResponseSchema = createResponseSchema(
+  z.object({
+    address: z.string(),
+    transaction: z.string(),
+    networkPassphrase: z.string(),
+  })
+)
+
+export type ResponseSchemaT = z.infer<typeof ResponseSchema>

--- a/apps/backend/src/interfaces/wallet-backend/index.ts
+++ b/apps/backend/src/interfaces/wallet-backend/index.ts
@@ -7,6 +7,8 @@ import { getValueFromEnv } from 'config/env-utils'
 import { generateToken } from './auth/jwt'
 import {
   AccountRequest,
+  CreateSponsoredAccountRequest,
+  CreateSponsoredAccountResponse,
   GetTransactionsResponse,
   TransactionBuildRequest,
   TransactionBuildResponse,
@@ -161,5 +163,27 @@ export default class WalletBackend extends SingletonBase implements WalletBacken
       },
     })
     return response.data as TransactionResponse
+  }
+
+  public async createSponsoredAccount(address: string): Promise<CreateSponsoredAccountResponse> {
+    const createAccountUrl = '/tx/create-sponsored-account'
+
+    const requestBody: CreateSponsoredAccountRequest = {
+      address,
+      skipSponsorship: true,
+    }
+
+    const authToken = await generateToken({
+      methodAndPath: `POST ${createAccountUrl}`,
+      bodyHash: JSON.stringify(requestBody),
+    })
+
+    const response = await this.connection.post(createAccountUrl, requestBody, {
+      headers: {
+        Authorization: `Bearer ${authToken}`,
+      },
+    })
+
+    return response.data as CreateSponsoredAccountResponse
   }
 }

--- a/apps/backend/src/interfaces/wallet-backend/mock.ts
+++ b/apps/backend/src/interfaces/wallet-backend/mock.ts
@@ -9,5 +9,6 @@ export function mockWalletBackend(): Mocked<WalletBackendType> {
     getTransactions: vi.fn(),
     buildTransaction: vi.fn(),
     createFeeBumpTransaction: vi.fn(),
+    createSponsoredAccount: vi.fn(),
   }
 }

--- a/apps/backend/src/interfaces/wallet-backend/types.ts
+++ b/apps/backend/src/interfaces/wallet-backend/types.ts
@@ -74,10 +74,21 @@ export interface GetTransactionsResponse {
   account: AccountWithTransactions
 }
 
+export type CreateSponsoredAccountRequest = {
+  address: string
+  skipSponsorship: boolean
+}
+
+export type CreateSponsoredAccountResponse = {
+  transaction: string
+  networkPassphrase: string
+}
+
 export type WalletBackendType = {
   registerAccount(account: AccountRequest): Promise<object>
   deregisterAccount(account: AccountRequest): Promise<object>
   getTransactions(account: AccountRequest): Promise<GetTransactionsResponse>
   buildTransaction(transactions: TransactionBuildRequest): Promise<TransactionBuildResponse>
   createFeeBumpTransaction(transaction: TransactionRequest): Promise<TransactionResponse>
+  createSponsoredAccount(address: string): Promise<CreateSponsoredAccountResponse>
 }


### PR DESCRIPTION
### What

This implements the `/create-account` endpoint, which creates a Stellar account if it doesn't already exist. This endpoint is allowed to be called once per user.

### Why

Sponsor accounts that don't already exist for end of event transfer.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
