### PR TITLE
feat: endpoint to return nft metadata

### DIFF
--- a/apps/backend/src/api/core/entities/nft-supply/model.ts
+++ b/apps/backend/src/api/core/entities/nft-supply/model.ts
@@ -18,7 +18,7 @@ export class NftSupply extends ModelBase {
   })
   description: string
 
-  // NFT image URL: ipfs://QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/I/m/SomeImage.png, https://some.site/img/SomeImage.jpg, etc
+  // NFT resource/dir URL: https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco
   @Column({
     type: 'varchar',
   })

--- a/apps/backend/src/api/core/entities/nft-supply/types.ts
+++ b/apps/backend/src/api/core/entities/nft-supply/types.ts
@@ -12,6 +12,7 @@ export type NftSupplyRepositoryType = {
   getNftSupplyByResource(resource: string): Promise<NftSupply | null>
   getNftSupplyByResourceAndSessionId(resource: string, session_id: string): Promise<NftSupply | null>
   getNftSupplyByContractAndSessionId(contractAddress: string, session_id: string): Promise<NftSupply | null>
+  getNftSupplyByResourceAndTokenId(resource: string, tokenId: string): Promise<NftSupply | null>
   createNftSupply(
     nftSupply: {
       name: string

--- a/apps/backend/src/api/core/routes.ts
+++ b/apps/backend/src/api/core/routes.ts
@@ -13,6 +13,7 @@ import {
   adminProductsRoutes,
   adminNgosRoutes,
   ngosRoutes,
+  nftMetadataRoutes,
 } from '../general-settings/routes'
 
 function routes(http: express.Router): void {
@@ -30,6 +31,7 @@ function routes(http: express.Router): void {
   http.use('/api/admin/vendors', adminVendorsRoutes)
   http.use('/api/admin/products', adminProductsRoutes)
   http.use('/api/admin/ngos', adminNgosRoutes)
+  http.use('/nft-metadata', nftMetadataRoutes)
 }
 
 export { routes, Request, Response, Router, NextFunction }

--- a/apps/backend/src/api/core/services/nft-supply/index.ts
+++ b/apps/backend/src/api/core/services/nft-supply/index.ts
@@ -38,6 +38,14 @@ export default class NftSupplyRepository extends SingletonBase implements NftSup
     return NftSupplyModel.findOneBy({ contractAddress: ILike(contractAddress), sessionId })
   }
 
+  async getNftSupplyByResourceAndTokenId(resource: string, tokenId: string): Promise<NftSupply | null> {
+    return NftSupplyModel.createQueryBuilder('nftSupply')
+      .leftJoinAndSelect('nftSupply.nfts', 'nfts')
+      .where('nftSupply.resource = :resource', { resource })
+      .andWhere('nfts.tokenId = :tokenId', { tokenId })
+      .getOne()
+  }
+
   async createNftSupply(
     nftSupply: {
       name: string

--- a/apps/backend/src/api/core/services/nft-supply/mock.ts
+++ b/apps/backend/src/api/core/services/nft-supply/mock.ts
@@ -11,6 +11,7 @@ export function mockNftSupplyRepository(): Mocked<NftSupplyRepositoryType> {
     getNftSupplyByResource: vi.fn(),
     getNftSupplyByResourceAndSessionId: vi.fn(),
     getNftSupplyByContractAndSessionId: vi.fn(),
+    getNftSupplyByResourceAndTokenId: vi.fn(),
     createNftSupply: vi.fn(),
     updateNftSupply: vi.fn(),
     deleteNftSupply: vi.fn(),

--- a/apps/backend/src/api/core/utils/zod/index.ts
+++ b/apps/backend/src/api/core/utils/zod/index.ts
@@ -119,4 +119,19 @@ export const nftSupplySchema = z.object({
   issuer: z.string(),
 })
 
+export const nftMetadataSchema = z.object({
+  name: z.string(),
+  description: z.string(),
+  image: z.string(),
+  external_url: z.string(),
+  attributes: z
+    .array(
+      z.object({
+        trait_type: z.string(),
+        value: z.string().or(z.number()).or(z.boolean()),
+      })
+    )
+    .optional(),
+})
+
 export type MerkleProofDataT = z.infer<typeof merkleProofDataSchema>

--- a/apps/backend/src/api/general-settings/routes.ts
+++ b/apps/backend/src/api/general-settings/routes.ts
@@ -11,6 +11,7 @@ import { CreateProduct, endpoint as CreateProductEndpoint } from './use-cases/cr
 import { CreateVendor, endpoint as CreateVendorEndpoint } from './use-cases/create-vendor'
 import { GetAssets, endpoint as GetAssetsEndpoint } from './use-cases/get-assets'
 import { GetFeatureFlags, endpoint as GetFeatureFlagsEndpoint } from './use-cases/get-feature-flags'
+import { GetNftMetadata, endpoint as GetNftMetadataEndpoint } from './use-cases/get-nft-metadata'
 import { GetNftSupply, endpoint as GetNftSupplyEndpoint } from './use-cases/get-nft-supply'
 import { GetNgos, endpoint as GetNgosEndpoint } from './use-cases/get-ngos'
 import { GetProducts, endpoint as GetProductsEndpoint } from './use-cases/get-products'
@@ -96,6 +97,9 @@ adminNgosRoutes.patch(`${UpdateNgoEndpoint}`, apiKeyAuthentication, async (req, 
   UpdateNgo.init().executeHttp(req, res)
 )
 
+const nftMetadataRoutes = Router()
+nftMetadataRoutes.get(`${GetNftMetadataEndpoint}`, async (req, res) => GetNftMetadata.init().executeHttp(req, res))
+
 export {
   featureFlagsRoutes,
   adminFeatureFlagsRoutes,
@@ -105,4 +109,5 @@ export {
   adminNgosRoutes,
   adminNftSupplyRoutes,
   adminProductsRoutes,
+  nftMetadataRoutes,
 }

--- a/apps/backend/src/api/general-settings/use-cases/get-nft-metadata/index.ts
+++ b/apps/backend/src/api/general-settings/use-cases/get-nft-metadata/index.ts
@@ -1,0 +1,65 @@
+import { Request, Response } from 'express'
+
+import { NftSupply, NftSupplyRepositoryType } from 'api/core/entities/nft-supply/types'
+import { UseCaseBase } from 'api/core/framework/use-case/base'
+import { IUseCaseHttp } from 'api/core/framework/use-case/http'
+import NftSupplyRepository from 'api/core/services/nft-supply'
+import { HttpStatusCodes } from 'api/core/utils/http/status-code'
+import { messages } from 'api/embedded-wallets/constants/messages'
+import { ResourceNotFoundException } from 'errors/exceptions/resource-not-found'
+
+import { RequestSchema, RequestSchemaT, ResponseSchemaT } from './types'
+
+const endpoint = '/:resource/:id'
+
+export class GetNftMetadata extends UseCaseBase implements IUseCaseHttp<ResponseSchemaT> {
+  private nftSupplyRepository: NftSupplyRepositoryType
+
+  constructor(nftSupplyRepository?: NftSupplyRepositoryType) {
+    super()
+    this.nftSupplyRepository = nftSupplyRepository || NftSupplyRepository.getInstance()
+  }
+
+  async executeHttp(request: Request, response: Response<ResponseSchemaT>) {
+    const tokenId = request.params?.id
+    const resource = request.params?.resource
+    const payload = { id: tokenId, resource: resource } as RequestSchemaT
+    const result = await this.handle(payload)
+    return response.status(HttpStatusCodes.OK).json(result)
+  }
+
+  parseResponse(tokenId: string | number, nftSupply: NftSupply) {
+    return {
+      name: `${nftSupply.name} #${tokenId}`,
+      description: `${nftSupply.description} #${tokenId}`,
+      image: nftSupply.url,
+      external_url: nftSupply.url,
+      attributes: [
+        {
+          trait_type: 'Token ID',
+          value: tokenId as number,
+        },
+        {
+          trait_type: 'Collection',
+          value: nftSupply.name,
+        },
+      ],
+    }
+  }
+
+  async handle(payload: RequestSchemaT) {
+    const validatedData = this.validate(payload, RequestSchema)
+
+    const nftSupply = await this.nftSupplyRepository.getNftSupplyByResourceAndTokenId(
+      validatedData.resource,
+      validatedData.id
+    )
+    if (!nftSupply) {
+      throw new ResourceNotFoundException(messages.NFT_SUPPLY_NOT_FOUND)
+    }
+
+    return this.parseResponse(validatedData.id, nftSupply)
+  }
+}
+
+export { endpoint }

--- a/apps/backend/src/api/general-settings/use-cases/get-nft-metadata/types.ts
+++ b/apps/backend/src/api/general-settings/use-cases/get-nft-metadata/types.ts
@@ -1,0 +1,14 @@
+import { z } from 'zod'
+
+import { nftMetadataSchema } from 'api/core/utils/zod'
+
+export const RequestSchema = z.object({
+  id: z.string(),
+  resource: z.string(),
+})
+
+export type RequestSchemaT = z.infer<typeof RequestSchema>
+
+export const ResponseSchema = nftMetadataSchema
+
+export type ResponseSchemaT = z.infer<typeof ResponseSchema>


### PR DESCRIPTION
### What

Endpoint that returns NFT metadata in SEP-50 format

#### Example call

`GET http://localhost:8000/nft-metadata/:resource/token_id`

`GET http://localhost:8000/nft-metadata/talk/18`

### Why

So that external integrations can get token metadata to render properly.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
