### PR TITLE
feat: add zoom capabilities to qr code scanner

### DIFF
--- a/apps/web/src/interfaces/qr-scanner/index.ts
+++ b/apps/web/src/interfaces/qr-scanner/index.ts
@@ -24,7 +24,6 @@ class QrScanner {
   private minZoom: number = 1
   private maxZoom: number = 1
   private currentZoom: number = 1
-  private lastTouchDistance: number = 0
   private touchStartDistance: number = 0
   private initialZoom: number = 1
 
@@ -68,12 +67,11 @@ class QrScanner {
       await this.scanner.start(
         { facingMode: 'environment' },
         {
-          fps: 12,
+          fps: 10,
           qrbox: {
             width: window.innerWidth, 
             height: window.innerHeight 
           },
-          formatsToSupport: [ Html5QrcodeSupportedFormats.QR_CODE ],
         },
         onScan,
         (errorMessage: string, error: Html5QrcodeError) => {
@@ -84,6 +82,9 @@ class QrScanner {
           onError?.(errorMessage, error)
         }
       )
+
+      // Apply full-height styles after scanner starts
+      this.applyFullHeightStyles()
     } catch (error) {
       if (typeof error === 'string' && notTrackableErrors.some(value => error.includes(value))) return
 
@@ -167,6 +168,34 @@ class QrScanner {
     } catch (error) {
       logger.error(`${this.constructor.name}.applyZoom | Failed to apply zoom ${zoom}`, error)
     }
+  }
+
+  private applyFullHeightStyles(): void {
+    const scannerElement = document.getElementById(this.elementId)
+    if (!scannerElement) return
+
+    // Apply styles to the scanner container
+    scannerElement.style.width = '100%'
+    scannerElement.style.height = '100%'
+    scannerElement.style.position = 'relative'
+
+    // Find and style the video element
+    const videoElement = scannerElement.querySelector('video')
+    if (videoElement) {
+      videoElement.style.width = '100%'
+      videoElement.style.height = '100%'
+      videoElement.style.objectFit = 'cover'
+      videoElement.style.position = 'absolute'
+      videoElement.style.top = '0'
+      videoElement.style.left = '0'
+    }
+
+    // Style any child divs
+    const childDivs = scannerElement.querySelectorAll('div')
+    childDivs.forEach(div => {
+      div.style.width = '100%'
+      div.style.height = '100%'
+    })
   }
 
   async stop(): Promise<void> {

--- a/apps/web/src/interfaces/qr-scanner/index.ts
+++ b/apps/web/src/interfaces/qr-scanner/index.ts
@@ -77,11 +77,10 @@ class QrScanner {
 
     const stream = videoElement.srcObject as MediaStream
     this.videoTrack = stream.getVideoTracks()[0]
-    
+
     if (!this.videoTrack) return
 
     const capabilities = this.videoTrack.getCapabilities()
-    
     // Safely access zoom capabilities (not in standard TypeScript definitions yet)
     const zoomCapabilities = (capabilities as any).zoom
     this.minZoom = zoomCapabilities?.min || 1

--- a/apps/web/src/interfaces/qr-scanner/index.ts
+++ b/apps/web/src/interfaces/qr-scanner/index.ts
@@ -1,5 +1,6 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
 import { Html5Qrcode } from 'html5-qrcode'
-import { Html5QrcodeError, Html5QrcodeResult, Html5QrcodeSupportedFormats } from 'html5-qrcode/esm/core'
+import { Html5QrcodeError, Html5QrcodeResult } from 'html5-qrcode/esm/core'
 
 import logger from 'src/app/core/services/logger'
 import { ErrorHandling } from 'src/helpers/error-handling'
@@ -39,38 +40,38 @@ class QrScanner {
 
     try {
       const videoConstraints = {
-        facingMode: "environment",
-      };
+        facingMode: 'environment',
+      }
       const stream = await navigator.mediaDevices.getUserMedia({
         video: videoConstraints,
-      });
+      })
 
-      this.videoTrack = stream.getVideoTracks()[0];
-      const capabilities = this.videoTrack.getCapabilities();
-      
+      this.videoTrack = stream.getVideoTracks()[0]
+      const capabilities = this.videoTrack.getCapabilities()
+
       // Safely access zoom capabilities (not in standard TypeScript definitions yet)
-      const zoomCapabilities = (capabilities as any).zoom;
-      this.minZoom = zoomCapabilities?.min || 1;
-      this.maxZoom = zoomCapabilities?.max || 1;
-      this.currentZoom = Math.max(this.minZoom, 1);
+      const zoomCapabilities = (capabilities as any).zoom
+      this.minZoom = zoomCapabilities?.min || 1
+      this.maxZoom = zoomCapabilities?.max || 1
+      this.currentZoom = Math.max(this.minZoom, 1)
 
       // Apply initial zoom if supported
       if (zoomCapabilities) {
         const constraints = {
           advanced: [{ zoom: this.currentZoom }],
-        } as any;
-        await this.videoTrack.applyConstraints(constraints);
+        } as any
+        await this.videoTrack.applyConstraints(constraints)
       }
-      
-      this.addPinchToZoomListeners();
-      
+
+      this.addPinchToZoomListeners()
+
       await this.scanner.start(
         { facingMode: 'environment' },
         {
           fps: 10,
           qrbox: {
-            width: window.innerWidth, 
-            height: window.innerHeight 
+            width: window.innerWidth,
+            height: window.innerHeight,
           },
         },
         onScan,
@@ -120,21 +121,21 @@ class QrScanner {
   private handleTouchMove(event: TouchEvent): void {
     if (event.touches.length === 2 && this.videoTrack) {
       event.preventDefault()
-      
+
       const currentDistance = this.getTouchDistance(event.touches[0], event.touches[1])
       const distanceChange = currentDistance - this.touchStartDistance
-      
+
       // Calculate zoom change based on distance change
       // Scale factor: adjust sensitivity (higher = more sensitive)
       const scaleFactor = 0.01
       const zoomChange = distanceChange * scaleFactor
-      
+
       // Calculate new zoom level
       let newZoom = this.initialZoom + zoomChange
-      
+
       // Clamp zoom to camera limits
       newZoom = Math.max(this.minZoom, Math.min(this.maxZoom, newZoom))
-      
+
       // Only apply zoom if it's significantly different to avoid excessive API calls
       if (Math.abs(newZoom - this.currentZoom) > 0.1) {
         this.currentZoom = newZoom
@@ -203,10 +204,10 @@ class QrScanner {
       try {
         // Remove pinch-to-zoom listeners
         this.removePinchToZoomListeners()
-        
+
         await this.scanner.stop()
         this.scanner.clear()
-        
+
         // Reset zoom state
         this.videoTrack = null
         this.currentZoom = 1


### PR DESCRIPTION
What
Added pinch-to-zoom functionality to the QR scanner component, allowing users to control camera zoom levels using two-finger pinch gestures on touch devices.

Why
The existing QR scanner lacked intuitive zoom controls for users to better focus on QR codes at different distances. This enhancement improves the user experience by providing native camera-like zoom functionality that users expect from modern mobile applications. The implementation uses touch events to detect pinch gestures and maps them to camera zoom levels, making QR code scanning more accessible and user-friendly across different device types and scanning scenarios.

Checklist

PR Structure
[x] It is not possible to break this PR down into smaller PRs.
[x] This PR does not mix refactoring changes with feature changes.

Thoroughness
[ ] This PR adds tests for the new functionality or fixes.

Release
[x] This is not a breaking change.
[x] This is ready to be tested in development.
[x] The new functionality is gated with a feature flag if this is not ready for production.

Note: The functionality is automatically enabled when the QR scanner starts and gracefully degrades on devices that don't support zoom capabilities or touch events.