### PR TITLE
Hotfix(backend): check account existence only for non contract wallets

### DIFF
--- a/apps/backend/src/api/embedded-wallets/use-cases/transfer-options/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/transfer-options/index.ts
@@ -1,4 +1,4 @@
-import { xdr, nativeToScVal } from '@stellar/stellar-sdk'
+import { xdr, nativeToScVal, StrKey } from '@stellar/stellar-sdk'
 import { Request, Response } from 'express'
 
 import { AssetRepositoryType } from 'api/core/entities/asset/types'
@@ -95,8 +95,8 @@ export class TransferOptions extends UseCaseBase implements IUseCaseHttp<Respons
       throw new ResourceNotFoundException(messages.USER_DOES_NOT_HAVE_PASSKEYS)
     }
 
-    // Validate if 'to' address is non-existent
-    if (validatedData.to) {
+    // Validate if 'to' address is non-existent (exclusive for not contract wallets)
+    if (!StrKey.isValidContract(validatedData.to) && validatedData.to) {
       const validAddress = await fetch(`${getValueFromEnv('STELLAR_HORIZON_URL')}/accounts/${validatedData.to}`)
 
       if (validAddress.status !== 200) {

--- a/apps/backend/src/api/embedded-wallets/use-cases/transfer/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/transfer/index.ts
@@ -1,4 +1,4 @@
-import { rpc } from '@stellar/stellar-sdk'
+import { rpc, StrKey } from '@stellar/stellar-sdk'
 import { Request, Response } from 'express'
 
 import { Nft } from 'api/core/entities/nft/model'
@@ -101,8 +101,8 @@ export class Transfer extends UseCaseBase implements IUseCaseHttp<ResponseSchema
       throw new ResourceNotFoundException(messages.USER_DOES_NOT_HAVE_PASSKEYS)
     }
 
-    // Validate if 'to' address is non-existent
-    if (validatedData.to) {
+    // Validate if 'to' address is non-existent (exclusive for not contract wallets)
+    if (!StrKey.isValidContract(validatedData.to) && validatedData.to) {
       const validAddress = await fetch(`${getValueFromEnv('STELLAR_HORIZON_URL')}/accounts/${validatedData.to}`)
 
       if (validAddress.status !== 200) {


### PR DESCRIPTION
### What

- Checks account existence only for non-contract wallets

### Why

- Smart Contract wallets sometimes don't appear available in HORIZON_URL. We should always consider that they are available on the app

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
