### PR TITLE
fix: fixed qr code layout proportion and add touch prevention to avoi…

### DIFF
--- a/apps/web/index.html
+++ b/apps/web/index.html
@@ -8,13 +8,17 @@
     <meta name="author" content="Stellar" />
 
     <!-- Viewport for responsive mobile -->
-    <meta name="viewport" content="width=device-width, initial-scale=1, viewport-fit=cover, maximum-scale=1" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, user-scalable=no, viewport-fit=cover" />
 
     <!-- Theme Colors for browsers & OS -->
     <meta name="theme-color" content="#000000" />
     <meta name="apple-mobile-web-app-title" content="Smart Wallet" />
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent" />
     <meta name="apple-mobile-web-app-capable" content="yes" />
+    
+    <!-- Additional Safari/iOS zoom prevention -->
+    <meta name="format-detection" content="telephone=no" />
+    <meta name="apple-touch-fullscreen" content="yes" />
 
     <!-- Icons -->
     <link rel="apple-touch-icon" sizes="180x180" href="/apple-touch-icon.png">

--- a/apps/web/src/app/wallet/pages/scan/styles.module.css
+++ b/apps/web/src/app/wallet/pages/scan/styles.module.css
@@ -1,9 +1,10 @@
 .cutout {
   position: absolute;
-  top: calc(50% - 40vw);
-  left: calc(50% - 40vw);
-  width: 80vw;
-  height: 80vw;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  width: min(80vw, 90%);
+  height: min(80vw, 60vh);
   border-radius: 16px;
   box-shadow: 0 0 0 9999px rgba(255, 255, 255, 0.7);
 }

--- a/apps/web/src/interfaces/qr-scanner/index.ts
+++ b/apps/web/src/interfaces/qr-scanner/index.ts
@@ -42,7 +42,7 @@ class QrScanner {
       await this.scanner.start(
         { facingMode: 'environment' },
         {
-          fps: 10,
+          fps: 20,
           qrbox: {
             width: window.innerWidth,
             height: window.innerHeight,
@@ -92,21 +92,25 @@ class QrScanner {
     if (!this.videoTrack) return
 
     // Touch event handlers on window to ensure they work regardless of scanner DOM structure
-    window.addEventListener('touchstart', this.handleTouchStart.bind(this), { passive: false })
-    window.addEventListener('touchmove', this.handleTouchMove.bind(this), { passive: false })
-    window.addEventListener('touchend', this.handleTouchEnd.bind(this), { passive: false })
+    // Use capture phase and non-passive to ensure preventDefault works
+    window.addEventListener('touchstart', this.handleTouchStart.bind(this), { passive: false, capture: true } as AddEventListenerOptions)
+    window.addEventListener('touchmove', this.handleTouchMove.bind(this), { passive: false, capture: true } as AddEventListenerOptions)
+    window.addEventListener('touchend', this.handleTouchEnd.bind(this), { passive: false, capture: true } as AddEventListenerOptions)
   }
 
   private removePinchToZoomListeners(): void {
-    // Remove event handlers from window
-    window.removeEventListener('touchstart', this.handleTouchStart.bind(this))
-    window.removeEventListener('touchmove', this.handleTouchMove.bind(this))
-    window.removeEventListener('touchend', this.handleTouchEnd.bind(this))
+    // Remove event handlers from window with same options
+    window.removeEventListener('touchstart', this.handleTouchStart.bind(this), { passive: false, capture: true } as AddEventListenerOptions)
+    window.removeEventListener('touchmove', this.handleTouchMove.bind(this), { passive: false, capture: true } as AddEventListenerOptions)
+    window.removeEventListener('touchend', this.handleTouchEnd.bind(this), { passive: false, capture: true } as AddEventListenerOptions)
   }
 
   private handleTouchStart(event: TouchEvent): void {
     if (event.touches.length === 2) {
+      // Prevent default browser zoom behavior
       event.preventDefault()
+      event.stopPropagation()
+      
       this.touchStartDistance = this.getTouchDistance(event.touches[0], event.touches[1])
       this.initialZoom = this.currentZoom
     }
@@ -114,7 +118,9 @@ class QrScanner {
 
   private handleTouchMove(event: TouchEvent): void {
     if (event.touches.length === 2 && this.videoTrack) {
+      // Prevent default browser zoom behavior
       event.preventDefault()
+      event.stopPropagation()
 
       const currentDistance = this.getTouchDistance(event.touches[0], event.touches[1])
       const distanceChange = currentDistance - this.touchStartDistance
@@ -173,6 +179,12 @@ class QrScanner {
     scannerElement.style.width = '100%'
     scannerElement.style.height = '100%'
     scannerElement.style.position = 'relative'
+    
+    // Prevent zoom behavior on Safari/iOS
+    scannerElement.style.touchAction = 'none'
+    scannerElement.style.userSelect = 'none'
+    scannerElement.style.webkitUserSelect = 'none'
+    ;(scannerElement.style as any).webkitTouchCallout = 'none'
 
     // Find and style the video element
     const videoElement = scannerElement.querySelector('video')
@@ -183,6 +195,12 @@ class QrScanner {
       videoElement.style.position = 'absolute'
       videoElement.style.top = '0'
       videoElement.style.left = '0'
+      
+      // Additional Safari/iOS zoom prevention
+      videoElement.style.touchAction = 'none'
+      videoElement.style.userSelect = 'none'
+      videoElement.style.webkitUserSelect = 'none'
+      ;(videoElement.style as any).webkitTouchCallout = 'none'
     }
 
     // Style any child divs
@@ -190,6 +208,10 @@ class QrScanner {
     childDivs.forEach(div => {
       div.style.width = '100%'
       div.style.height = '100%'
+      div.style.touchAction = 'none'
+      div.style.userSelect = 'none'
+      div.style.webkitUserSelect = 'none'
+      ;(div.style as any).webkitTouchCallout = 'none'
     })
   }
 

--- a/apps/web/src/interfaces/qr-scanner/index.ts
+++ b/apps/web/src/interfaces/qr-scanner/index.ts
@@ -93,16 +93,34 @@ class QrScanner {
 
     // Touch event handlers on window to ensure they work regardless of scanner DOM structure
     // Use capture phase and non-passive to ensure preventDefault works
-    window.addEventListener('touchstart', this.handleTouchStart.bind(this), { passive: false, capture: true } as AddEventListenerOptions)
-    window.addEventListener('touchmove', this.handleTouchMove.bind(this), { passive: false, capture: true } as AddEventListenerOptions)
-    window.addEventListener('touchend', this.handleTouchEnd.bind(this), { passive: false, capture: true } as AddEventListenerOptions)
+    window.addEventListener('touchstart', this.handleTouchStart.bind(this), {
+      passive: false,
+      capture: true,
+    } as AddEventListenerOptions)
+    window.addEventListener('touchmove', this.handleTouchMove.bind(this), {
+      passive: false,
+      capture: true,
+    } as AddEventListenerOptions)
+    window.addEventListener('touchend', this.handleTouchEnd.bind(this), {
+      passive: false,
+      capture: true,
+    } as AddEventListenerOptions)
   }
 
   private removePinchToZoomListeners(): void {
     // Remove event handlers from window with same options
-    window.removeEventListener('touchstart', this.handleTouchStart.bind(this), { passive: false, capture: true } as AddEventListenerOptions)
-    window.removeEventListener('touchmove', this.handleTouchMove.bind(this), { passive: false, capture: true } as AddEventListenerOptions)
-    window.removeEventListener('touchend', this.handleTouchEnd.bind(this), { passive: false, capture: true } as AddEventListenerOptions)
+    window.removeEventListener('touchstart', this.handleTouchStart.bind(this), {
+      passive: false,
+      capture: true,
+    } as AddEventListenerOptions)
+    window.removeEventListener('touchmove', this.handleTouchMove.bind(this), {
+      passive: false,
+      capture: true,
+    } as AddEventListenerOptions)
+    window.removeEventListener('touchend', this.handleTouchEnd.bind(this), {
+      passive: false,
+      capture: true,
+    } as AddEventListenerOptions)
   }
 
   private handleTouchStart(event: TouchEvent): void {
@@ -110,7 +128,7 @@ class QrScanner {
       // Prevent default browser zoom behavior
       event.preventDefault()
       event.stopPropagation()
-      
+
       this.touchStartDistance = this.getTouchDistance(event.touches[0], event.touches[1])
       this.initialZoom = this.currentZoom
     }
@@ -179,7 +197,7 @@ class QrScanner {
     scannerElement.style.width = '100%'
     scannerElement.style.height = '100%'
     scannerElement.style.position = 'relative'
-    
+
     // Prevent zoom behavior on Safari/iOS
     scannerElement.style.touchAction = 'none'
     scannerElement.style.userSelect = 'none'
@@ -195,7 +213,7 @@ class QrScanner {
       videoElement.style.position = 'absolute'
       videoElement.style.top = '0'
       videoElement.style.left = '0'
-      
+
       // Additional Safari/iOS zoom prevention
       videoElement.style.touchAction = 'none'
       videoElement.style.userSelect = 'none'


### PR DESCRIPTION
Prevent Safari/iOS browser zoom interference with camera zoom

What
Enhanced QR scanner touch event handling and layout viewport management to prevent Safari/iOS browser zoom from interfering with camera zoom functionality.

Why
Safari/iOS was applying browser zoom gestures alongside the custom camera zoom, causing:
Inconsistent zoom behavior between Android (working) and iOS (broken)
Poor user experience when trying to zoom the camera

Checklist

PR Structure
[x] It is not possible to break this PR down into smaller PRs.
[x] This PR does not mix refactoring changes with feature changes.

Thoroughness
[ ] This PR adds tests for the new functionality or fixes.

Release
[x] This is not a breaking change.
[x] This is ready to be tested in development.
[x] The new functionality is gated with a feature flag if this is not ready for production.