### PR TITLE
refactor(nft): make set_token_data private

### DIFF
--- a/contracts/nft/src/contract.rs
+++ b/contracts/nft/src/contract.rs
@@ -55,7 +55,7 @@ impl Contract {
         owner.require_auth();
     }
 
-    pub fn set_token_data(env: &Env, token_id: u32, data: TokenData) {
+    fn set_token_data(env: &Env, token_id: u32, data: TokenData) {
         env.storage()
             .instance()
             .set(&DataKey::TokenData(token_id), &data);

--- a/contracts/nft/src/test.rs
+++ b/contracts/nft/src/test.rs
@@ -501,48 +501,6 @@ fn test_metadata_persistence() {
 }
 
 #[test]
-fn test_set_token_data() {
-    let env = setup_test_env();
-    let owner = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let contract = get_contract(&env, &owner, 100u32);
-
-    let token_id = contract.mint(&recipient);
-
-    let token_data = crate::types::TokenData {
-        session_id: String::from_str(&env, "session_123"),
-        resource: String::from_str(&env, "resource_456"),
-    };
-
-    contract.set_token_data(&token_id, &token_data);
-
-    let retrieved_data = contract.get_token_data(&token_id);
-    assert_eq!(retrieved_data.session_id, token_data.session_id);
-    assert_eq!(retrieved_data.resource, token_data.resource);
-}
-
-#[test]
-fn test_get_token_data() {
-    let env = setup_test_env();
-    let owner = Address::generate(&env);
-    let recipient = Address::generate(&env);
-    let contract = get_contract(&env, &owner, 100u32);
-
-    let token_id = contract.mint(&recipient);
-
-    let token_data = crate::types::TokenData {
-        session_id: String::from_str(&env, "session_789"),
-        resource: String::from_str(&env, "resource_abc"),
-    };
-
-    contract.set_token_data(&token_id, &token_data);
-
-    let retrieved_data = contract.get_token_data(&token_id);
-    assert_eq!(retrieved_data.session_id, token_data.session_id);
-    assert_eq!(retrieved_data.resource, token_data.resource);
-}
-
-#[test]
 fn test_mint_with_data() {
     let env = setup_test_env();
     let owner = Address::generate(&env);

--- a/scripts/helpers/pinata.mjs
+++ b/scripts/helpers/pinata.mjs
@@ -7,6 +7,29 @@ import { DIRECTORIES } from '../nft/config.mjs';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
+const SUPPORTED_IMAGE_FORMATS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'];
+const SUPPORTED_ANIMATION_FORMATS = ['.mp4', '.webm', '.mov', '.ogg', '.mp3', '.wav', '.m4a'];
+
+const findAssetFile = (tokenId, supportedFormats) => {
+  for (const format of supportedFormats) {
+    const filePath = `${DIRECTORIES.IMAGES_DIR}/${tokenId}${format}`;
+
+    if (existsSync(filePath)) {
+      return { path: filePath, extension: format };
+    }
+  }
+
+  return null;
+};
+
+const getFileMetadataField = (extension) => {
+  if (SUPPORTED_ANIMATION_FORMATS.includes(extension)) {
+    return 'animation_url';
+  }
+
+  return 'image';
+};
+
 const isPinataInstalled = () => {
   try {
     return execSync(`which pinata`, { stdio: 'pipe' });
@@ -97,34 +120,58 @@ const _createMetadataFiles = (imageUrl) => {
   const contractName = process.env.STELLAR_NFT_CONTRACT_NAME;
   const contractSymbol = process.env.STELLAR_NFT_CONTRACT_SYMBOL;
 
-  for (let i = 0; i < process.env.STELLAR_NFT_CONTRACT_MAX_SUPPLY; i++) {
-    if (!existsSync(`${DIRECTORIES.IMAGES_DIR}/${i}.png`)) {
-      logError(`image ${i} not found in ${DIRECTORIES.IMAGES_DIR}`);
+  for (let index = 0; index < process.env.STELLAR_NFT_CONTRACT_MAX_SUPPLY; index++) {
+    const allSupportedFormats = [...SUPPORTED_IMAGE_FORMATS, ...SUPPORTED_ANIMATION_FORMATS];
+    const assetFile = findAssetFile(index, allSupportedFormats);
+    
+    if (!assetFile) {
+      logError(`No supported asset file found for token ${index} in ${DIRECTORIES.IMAGES_DIR}`);
+      logInfo(`Supported formats: ${allSupportedFormats.join(', ')}`);
 
       return false;
     }
 
+    const fieldName = getFileMetadataField(assetFile.extension);
+    const fileUrl = `${imageUrl}/${index}${assetFile.extension}`;
+
     const tokenMetadata = {
-      name: `${contractSymbol} #${i}`,
-      description: `${contractName} NFT #${i}`,
-      image: `${imageUrl}/${i}.png`,
+      name: `${contractSymbol} #${index}`,
+      description: `${contractName} NFT #${index}`,
       external_url: imageUrl, // ! todo: change to the actual url
       attributes: [
         {
           trait_type: "Token ID",
-          value: i
+          value: index
         },
         {
           trait_type: "Collection",
           value: contractSymbol
-        }
+        },
+        {
+          trait_type: "File Type",
+          value: assetFile.extension.substring(1).toUpperCase()
+        },
+        {
+          trait_type: "File URL",
+          value: fileUrl
+        },
       ]
     };
 
-    const tokenMetadataPath = join(DIRECTORIES.METADATA_DIR, `${i}`);
+    if (fieldName === 'animation_url') {
+      const imageFile = findAssetFile(index, SUPPORTED_IMAGE_FORMATS);
+
+      if (imageFile) {
+        tokenMetadata.image = `${imageUrl}/${index}${imageFile.extension}`;
+      }
+    } else {
+      tokenMetadata.image = fileUrl;
+    }
+
+    const tokenMetadataPath = join(DIRECTORIES.METADATA_DIR, `${index}`);
 
     writeFileSync(tokenMetadataPath, JSON.stringify(tokenMetadata, null, 2));
-    logSuccess(`token ${i} metadata created: ${tokenMetadataPath}`);
+    logSuccess(`token ${index} metadata created: ${tokenMetadataPath} (${fieldName}: ${assetFile.extension})`);
   }
 
   return true;


### PR DESCRIPTION
### What

make set_token_data private because it has no auth check and it is used only in mint_with_data (which does the auth check)

### Why

so unauthorized actors can't invoke set_token_data

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
