### PR TITLE
fix(nft): update nft scripts to allow other types besides png

### DIFF
--- a/scripts/helpers/pinata.mjs
+++ b/scripts/helpers/pinata.mjs
@@ -7,6 +7,29 @@ import { DIRECTORIES } from '../nft/config.mjs';
 import { existsSync, mkdirSync, writeFileSync } from 'fs';
 import { join } from 'path';
 
+const SUPPORTED_IMAGE_FORMATS = ['.png', '.jpg', '.jpeg', '.gif', '.webp', '.svg'];
+const SUPPORTED_ANIMATION_FORMATS = ['.mp4', '.webm', '.mov', '.ogg', '.mp3', '.wav', '.m4a'];
+
+const findAssetFile = (tokenId, supportedFormats) => {
+  for (const format of supportedFormats) {
+    const filePath = `${DIRECTORIES.IMAGES_DIR}/${tokenId}${format}`;
+
+    if (existsSync(filePath)) {
+      return { path: filePath, extension: format };
+    }
+  }
+
+  return null;
+};
+
+const getFileMetadataField = (extension) => {
+  if (SUPPORTED_ANIMATION_FORMATS.includes(extension)) {
+    return 'animation_url';
+  }
+
+  return 'image';
+};
+
 const isPinataInstalled = () => {
   try {
     return execSync(`which pinata`, { stdio: 'pipe' });
@@ -97,34 +120,58 @@ const _createMetadataFiles = (imageUrl) => {
   const contractName = process.env.STELLAR_NFT_CONTRACT_NAME;
   const contractSymbol = process.env.STELLAR_NFT_CONTRACT_SYMBOL;
 
-  for (let i = 0; i < process.env.STELLAR_NFT_CONTRACT_MAX_SUPPLY; i++) {
-    if (!existsSync(`${DIRECTORIES.IMAGES_DIR}/${i}.png`)) {
-      logError(`image ${i} not found in ${DIRECTORIES.IMAGES_DIR}`);
+  for (let index = 0; index < process.env.STELLAR_NFT_CONTRACT_MAX_SUPPLY; index++) {
+    const allSupportedFormats = [...SUPPORTED_IMAGE_FORMATS, ...SUPPORTED_ANIMATION_FORMATS];
+    const assetFile = findAssetFile(index, allSupportedFormats);
+    
+    if (!assetFile) {
+      logError(`No supported asset file found for token ${index} in ${DIRECTORIES.IMAGES_DIR}`);
+      logInfo(`Supported formats: ${allSupportedFormats.join(', ')}`);
 
       return false;
     }
 
+    const fieldName = getFileMetadataField(assetFile.extension);
+    const fileUrl = `${imageUrl}/${index}${assetFile.extension}`;
+
     const tokenMetadata = {
-      name: `${contractSymbol} #${i}`,
-      description: `${contractName} NFT #${i}`,
-      image: `${imageUrl}/${i}.png`,
+      name: `${contractSymbol} #${index}`,
+      description: `${contractName} NFT #${index}`,
       external_url: imageUrl, // ! todo: change to the actual url
       attributes: [
         {
           trait_type: "Token ID",
-          value: i
+          value: index
         },
         {
           trait_type: "Collection",
           value: contractSymbol
-        }
+        },
+        {
+          trait_type: "File Type",
+          value: assetFile.extension.substring(1).toUpperCase()
+        },
+        {
+          trait_type: "File URL",
+          value: fileUrl
+        },
       ]
     };
 
-    const tokenMetadataPath = join(DIRECTORIES.METADATA_DIR, `${i}`);
+    if (fieldName === 'animation_url') {
+      const imageFile = findAssetFile(index, SUPPORTED_IMAGE_FORMATS);
+
+      if (imageFile) {
+        tokenMetadata.image = `${imageUrl}/${index}${imageFile.extension}`;
+      }
+    } else {
+      tokenMetadata.image = fileUrl;
+    }
+
+    const tokenMetadataPath = join(DIRECTORIES.METADATA_DIR, `${index}`);
 
     writeFileSync(tokenMetadataPath, JSON.stringify(tokenMetadata, null, 2));
-    logSuccess(`token ${i} metadata created: ${tokenMetadataPath}`);
+    logSuccess(`token ${index} metadata created: ${tokenMetadataPath} (${fieldName}: ${assetFile.extension})`);
   }
 
   return true;


### PR DESCRIPTION
### What

update nft scripts to allow other types besides png

### Why

because mainly png, svg and mp4 will be used but other types are also supported

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.

logs:

```
cd scripts && npm run deploy-nft-ipfs -- \
  --source-account admin \
  --name "My Awesome Collection" \
  --symbol "MAC" \
  --supply 2 \
  --network testnet

> scripts@1.0.0 deploy-nft-ipfs
> node nft/deploy-nft-ipfs.mjs --source-account admin --name My Awesome Collection --symbol MAC --supply 2 --network testnet

Target Network: testnet
Source Account: admin
Contract Name: My Awesome Collection
Contract Symbol: MAC
Max Supply: 2

installing pinata cli
checking if pinata cli is installed...
✓ pinata cli is already installed

pinata authentication
setting up pinata cli authentication...
✓ pinata cli is already authenticated
Running: make build
stellar contract build
⚠️  A new release of stellar-cli is available: 23.0.0 -> 23.1.2
ℹ️  CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/amandagonsalves/.cargo/registry/src= cargo rustc --manifest-path=Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release
    Finished `release` profile [optimized] target(s) in 0.40s
ℹ️  Build Summary:
   Wasm File: /Users/amandagonsalves/Documents/ckl/smart-wallet-demo-app/contracts/target/wasm32v1-none/release/nft.wasm
   Wasm Hash: 490413a2c9d947cb07569f01f2f9830af1891c5ecf435f8cfe48823d120bdeee
   Exported Functions: 27 found
     • _
     • __constructor
     • approve
     • approve_for_all
     • balance
     • bulk_transfer
     • burn
     • burn_from
     • get_approved
     • get_max_supply
     • get_owner_token_id
     • get_owner_tokens
     • get_token_data
     • get_token_id
     • get_token_metadata
     • is_approved_for_all
     • mint
     • mint_with_data
     • name
     • only_owner
     • owner_of
     • set_metadata_uri
     • symbol
     • token_uri
     • total_supply
     • transfer
     • transfer_from
✅ Build Complete
Running: make upload
stellar contract upload \
		--network testnet \
		--source-account admin \
		--wasm ../target/wasm32v1-none/release/nft.wasm
⚠️  A new release of stellar-cli is available: 23.0.0 -> 23.1.2
ℹ️  Skipping install because wasm already installed
490413a2c9d947cb07569f01f2f9830af1891c5ecf435f8cfe48823d120bdeee
Running: make deploy
⚠️  A new release of stellar-cli is available: 23.0.0 -> 23.1.2
ℹ️  Skipping install because wasm already installed
ℹ️  Using wasm hash 490413a2c9d947cb07569f01f2f9830af1891c5ecf435f8cfe48823d120bdeee
ℹ️  Simulating deploy transaction…
ℹ️  Transaction hash is 2484eb8303d6e586d85d0030dac45be49f99600d5747370cb174cd7629616116
🔗 https://stellar.expert/explorer/testnet/tx/2484eb8303d6e586d85d0030dac45be49f99600d5747370cb174cd7629616116
ℹ️  Signing transaction: 2484eb8303d6e586d85d0030dac45be49f99600d5747370cb174cd7629616116
🌎 Submitting deploy transaction…
🔗 https://stellar.expert/explorer/testnet/contract/CBNEAAIRNEZW7PG5QG7JK7S77HBWAO2W3OWI3Z4LFSHYTUKB5CA672L6
✅ Deployed!
Deployed contract ID: CBNEAAIRNEZW7PG5QG7JK7S77HBWAO2W3OWI3Z4LFSHYTUKB5CA672L6

creating
creating nft images and metadata files...

uploading images to ipfs
uploading images to ipfs via pinata...
Running: pinata upload "/Users/amandagonsalves/Documents/ckl/smart-wallet-demo-app/scripts/assets/images"

uploading to ipfs
uploading images and metadata to ipfs via pinata...
✓ token 0 metadata created: /Users/amandagonsalves/Documents/ckl/smart-wallet-demo-app/scripts/assets/metadata/0 (image: .png)
✓ token 1 metadata created: /Users/amandagonsalves/Documents/ckl/smart-wallet-demo-app/scripts/assets/metadata/1 (image: .svg)
Running: pinata upload /Users/amandagonsalves/Documents/ckl/smart-wallet-demo-app/scripts/assets/metadata --name "My Awesome Collection-metadata"
✓ deployment completed successfully with metadata uri: https://jade-patient-bovid-261.mypinata.cloud/ipfs/bafybeiezgnxmjwhxcjyuba6cujbzsqkhexercsuqyueoqe6vzueeqz525y
amandagonsalves@3043 scripts % npm run deploy-nft-ipfs -- \
  --source-account admin \
  --name "My Awesome Collection" \
  --symbol "MAC" \
  --supply 3 \ 
  --network testnet

> scripts@1.0.0 deploy-nft-ipfs
> node nft/deploy-nft-ipfs.mjs --source-account admin --name My Awesome Collection --symbol MAC --supply 3 --network testnet

Target Network: testnet
Source Account: admin
Contract Name: My Awesome Collection
Contract Symbol: MAC
Max Supply: 3

installing pinata cli
checking if pinata cli is installed...
✓ pinata cli is already installed

pinata authentication
setting up pinata cli authentication...
✓ pinata cli is already authenticated
Running: make build
stellar contract build
⚠️  A new release of stellar-cli is available: 23.0.0 -> 23.1.2
ℹ️  CARGO_BUILD_RUSTFLAGS=--remap-path-prefix=/Users/amandagonsalves/.cargo/registry/src= cargo rustc --manifest-path=Cargo.toml --crate-type=cdylib --target=wasm32v1-none --release
    Finished `release` profile [optimized] target(s) in 0.30s
ℹ️  Build Summary:
   Wasm File: /Users/amandagonsalves/Documents/ckl/smart-wallet-demo-app/contracts/target/wasm32v1-none/release/nft.wasm
   Wasm Hash: 490413a2c9d947cb07569f01f2f9830af1891c5ecf435f8cfe48823d120bdeee
   Exported Functions: 27 found
     • _
     • __constructor
     • approve
     • approve_for_all
     • balance
     • bulk_transfer
     • burn
     • burn_from
     • get_approved
     • get_max_supply
     • get_owner_token_id
     • get_owner_tokens
     • get_token_data
     • get_token_id
     • get_token_metadata
     • is_approved_for_all
     • mint
     • mint_with_data
     • name
     • only_owner
     • owner_of
     • set_metadata_uri
     • symbol
     • token_uri
     • total_supply
     • transfer
     • transfer_from
✅ Build Complete
Running: make upload
stellar contract upload \
		--network testnet \
		--source-account admin \
		--wasm ../target/wasm32v1-none/release/nft.wasm
⚠️  A new release of stellar-cli is available: 23.0.0 -> 23.1.2
ℹ️  Skipping install because wasm already installed
490413a2c9d947cb07569f01f2f9830af1891c5ecf435f8cfe48823d120bdeee
Running: make deploy
⚠️  A new release of stellar-cli is available: 23.0.0 -> 23.1.2
ℹ️  Skipping install because wasm already installed
ℹ️  Using wasm hash 490413a2c9d947cb07569f01f2f9830af1891c5ecf435f8cfe48823d120bdeee
ℹ️  Simulating deploy transaction…
ℹ️  Transaction hash is 28983f0256beae1bbc7145a97fae4fbde9f776f0ef6a4bc99f70a0ae22900125
🔗 https://stellar.expert/explorer/testnet/tx/28983f0256beae1bbc7145a97fae4fbde9f776f0ef6a4bc99f70a0ae22900125
ℹ️  Signing transaction: 28983f0256beae1bbc7145a97fae4fbde9f776f0ef6a4bc99f70a0ae22900125
🌎 Submitting deploy transaction…
🔗 https://stellar.expert/explorer/testnet/contract/CBHYG2TBLSXPXIJTVYXTGQQQY5IL522QC5CEZ4BV5ANMBMKZTZA7S66G
✅ Deployed!
Deployed contract ID: CBHYG2TBLSXPXIJTVYXTGQQQY5IL522QC5CEZ4BV5ANMBMKZTZA7S66G

creating
creating nft images and metadata files...

uploading images to ipfs
uploading images to ipfs via pinata...
Running: pinata upload "/Users/amandagonsalves/Documents/ckl/smart-wallet-demo-app/scripts/assets/images"

uploading to ipfs
uploading images and metadata to ipfs via pinata...
✓ token 0 metadata created: /Users/amandagonsalves/Documents/ckl/smart-wallet-demo-app/scripts/assets/metadata/0 (image: .png)
✓ token 1 metadata created: /Users/amandagonsalves/Documents/ckl/smart-wallet-demo-app/scripts/assets/metadata/1 (image: .svg)
✓ token 2 metadata created: /Users/amandagonsalves/Documents/ckl/smart-wallet-demo-app/scripts/assets/metadata/2 (animation_url: .mp4)
Running: pinata upload /Users/amandagonsalves/Documents/ckl/smart-wallet-demo-app/scripts/assets/metadata --name "My Awesome Collection-metadata"
✓ deployment completed successfully with metadata uri: https://jade-patient-bovid-261.mypinata.cloud/ipfs/bafybeid6dfh6o4dymwmcejwcvaqjio7ddx3qcxfg6xnw7copknqvrrqm5u
```
