### PR TITLE
Feat(web): add limit to left-nfts transfer

### DIFF
--- a/apps/web/src/config/content.example.json
+++ b/apps/web/src/config/content.example.json
@@ -141,6 +141,7 @@
   "invalidClassicWalletAddressError": "Use a wallet address starting with G",
   "restrictedWalletAddressError": "This account requires memo. Use different one.",
   "transferNftsSelectNftError": "Please select at least one NFT to transfer",
+  "transferNftsSelectNftExceededError": "For smooth and reliable transfers, transfer NFTs in groups of 10. If you have more, please make multiple transfers.",
   "transferNftsConfirmTransferButton": "Confirm Transfer",
   "transferNftsNftsCount": "NFTs",
   "transferNftsSelectAllButton": "Select all",


### PR DESCRIPTION
### What

- Adds limit to left-nfts transfer

### Why

- API limitation for bulk_transfer nfts (we got errors on the chain level)

### Visual

| | |
|--------|--------|
| <video src="https://github.com/user-attachments/assets/59485d03-5b52-40f3-bc76-1c95ac38a6dd" />  | <video src="https://github.com/user-attachments/assets/e059a8a9-f095-4bdb-b7f2-8fa17867b4c0" /> | 

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
