### PR TITLE
Refactor(web): make deeplink live only in memory

### DIFF
--- a/apps/web/src/app/auth/constants/storage.ts
+++ b/apps/web/src/app/auth/constants/storage.ts
@@ -10,4 +10,3 @@ export const AIRDROP_STORAGE_KEY = `${APP_NAME}/airdrop`
 export const TRANSFER_LEFT_ASSETS_STORAGE_KEY = `${APP_NAME}/transfer-left-assets`
 export const BEHIND_SCENES_STORAGE_KEY = `${APP_NAME}/behind-scenes`
 export const LEFT_SWAGS_STORAGE_KEY = `${APP_NAME}/left-swags`
-export const DEEP_LINK_STORAGE_KEY = `${APP_NAME}/deep-link`

--- a/apps/web/src/app/core/store/deep-link/index.ts
+++ b/apps/web/src/app/core/store/deep-link/index.ts
@@ -1,7 +1,4 @@
 import { create } from 'zustand'
-import { createJSONStorage, persist } from 'zustand/middleware'
-
-import { DEEP_LINK_STORAGE_KEY } from 'src/app/auth/constants/storage'
 
 import { DeepLinkStoreFields, DeepLinkStoreState } from './types'
 
@@ -9,16 +6,8 @@ const INITIAL_STATE: DeepLinkStoreFields = {
   deepLink: null,
 }
 
-export const useDeepLinkStore = create<DeepLinkStoreState>()(
-  persist(
-    set => ({
-      ...INITIAL_STATE,
-      setDeepLink: deepLink => set({ deepLink }),
-      clearDeepLink: () => set({ deepLink: null }),
-    }),
-    {
-      name: DEEP_LINK_STORAGE_KEY,
-      storage: createJSONStorage(() => localStorage),
-    }
-  )
-)
+export const useDeepLinkStore = create<DeepLinkStoreState>()(set => ({
+  ...INITIAL_STATE,
+  setDeepLink: deepLink => set({ deepLink }),
+  clearDeepLink: () => set({ deepLink: null }),
+}))


### PR DESCRIPTION
### What

- Makes deeplink storage only live at memory level (no long persisting on localstorage)

### Why

- Not necessary to hold this information across sections/tabs

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
