### PR TITLE
Feat: add vendor marketing name

### DIFF
--- a/apps/backend/src/api/core/entities/vendor/factory.test.ts
+++ b/apps/backend/src/api/core/entities/vendor/factory.test.ts
@@ -6,6 +6,7 @@ describe('Vendor factory tests', () => {
 
     expect(mockedVendor.vendorId).not.toBeUndefined()
     expect(mockedVendor.name).not.toBeUndefined()
+    expect(mockedVendor.marketingName).not.toBeUndefined()
     expect(mockedVendor.description).not.toBeUndefined()
     expect(mockedVendor.isActive).not.toBeUndefined()
     expect(mockedVendor.displayOrder).not.toBeUndefined()
@@ -17,6 +18,7 @@ describe('Vendor factory tests', () => {
     const mockedVendor = vendorFactory({
       vendorId: 'xyz789',
       name: 'Galactic Shop',
+      marketingName: 'Galactic Shop Marketing Name',
       description: 'Galactic Shop description',
       isActive: true,
       displayOrder: 1,
@@ -26,6 +28,7 @@ describe('Vendor factory tests', () => {
 
     expect(mockedVendor.vendorId).toBe('xyz789')
     expect(mockedVendor.name).toBe('Galactic Shop')
+    expect(mockedVendor.marketingName).toBe('Galactic Shop Marketing Name')
     expect(mockedVendor.description).toBe('Galactic Shop description')
     expect(mockedVendor.isActive).toBe(true)
     expect(mockedVendor.displayOrder).toBe(1)

--- a/apps/backend/src/api/core/entities/vendor/factory.ts
+++ b/apps/backend/src/api/core/entities/vendor/factory.ts
@@ -5,6 +5,7 @@ import { Vendor } from 'api/core/entities/vendor/model'
 interface VendorFactoryArgs {
   vendorId?: string
   name?: string
+  marketingName?: string
   description?: string
   isActive?: boolean
   displayOrder?: number
@@ -15,6 +16,7 @@ interface VendorFactoryArgs {
 export const vendorFactory = ({
   vendorId,
   name,
+  marketingName,
   description,
   isActive,
   displayOrder,
@@ -24,6 +26,7 @@ export const vendorFactory = ({
   const vendor = new Vendor()
   vendor.vendorId = vendorId ?? faker.string.uuid()
   vendor.name = name ?? 'Vendor Name'
+  vendor.marketingName = marketingName ?? 'Vendor Marketing Name'
   vendor.description = description ?? 'Vendor description'
   vendor.isActive = isActive ?? true
   vendor.displayOrder = displayOrder ?? 0

--- a/apps/backend/src/api/core/entities/vendor/model.ts
+++ b/apps/backend/src/api/core/entities/vendor/model.ts
@@ -14,6 +14,12 @@ export class Vendor extends ModelBase {
     type: 'varchar',
     nullable: true,
   })
+  marketingName?: string
+
+  @Column({
+    type: 'varchar',
+    nullable: true,
+  })
   description?: string
 
   @Column({

--- a/apps/backend/src/api/core/entities/vendor/types.ts
+++ b/apps/backend/src/api/core/entities/vendor/types.ts
@@ -11,10 +11,11 @@ export type VendorRepositoryType = {
   createVendor(
     vendor: {
       name: string
+      marketingName?: string
       description?: string
       isActive?: boolean
       displayOrder?: number
-      contractAddress?: string
+      walletAddress?: string
       profileImage?: string
     },
     save?: boolean

--- a/apps/backend/src/api/core/migrations/1764016266048-add-vendor-marketing-name.ts
+++ b/apps/backend/src/api/core/migrations/1764016266048-add-vendor-marketing-name.ts
@@ -1,0 +1,13 @@
+import { MigrationInterface, QueryRunner } from 'typeorm'
+
+export class AddVendorMarketingName1764016266048 implements MigrationInterface {
+  readonly name: string = 'AddVendorMarketingName1764016266048'
+
+  public async up(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "vendor" ADD "marketing_name" character varying`)
+  }
+
+  public async down(queryRunner: QueryRunner): Promise<void> {
+    await queryRunner.query(`ALTER TABLE "vendor" DROP COLUMN "marketing_name"`)
+  }
+}

--- a/apps/backend/src/api/core/services/vendor/index.ts
+++ b/apps/backend/src/api/core/services/vendor/index.ts
@@ -24,6 +24,7 @@ export default class VendorRepository extends SingletonBase implements VendorRep
   async createVendor(
     vendor: {
       name: string
+      marketingName?: string
       description?: string
       isActive?: boolean
       displayOrder?: number

--- a/apps/backend/src/api/core/utils/zod/index.ts
+++ b/apps/backend/src/api/core/utils/zod/index.ts
@@ -74,6 +74,7 @@ export const assetSchema = z.object({
 export const vendorSchema = z.object({
   id: z.string(),
   name: z.string(),
+  marketing_name: z.string().optional(),
   description: z.string().optional(),
   is_active: z.boolean(),
   display_order: z.number().int().min(0),

--- a/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.test.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.test.ts
@@ -146,6 +146,7 @@ describe('GetWallet', () => {
       {
         id: activeVendor.vendorId,
         name: activeVendor.name,
+        marketing_name: activeVendor.marketingName,
         description: activeVendor.description,
         display_order: activeVendor.displayOrder,
         wallet_address: activeVendor.walletAddress,

--- a/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.ts
+++ b/apps/backend/src/api/embedded-wallets/use-cases/get-wallet/index.ts
@@ -313,6 +313,7 @@ export class GetWallet extends UseCaseBase implements IUseCaseHttp<ResponseSchem
     return vendors.map(vendor => ({
       id: vendor.vendorId,
       name: vendor.name,
+      marketing_name: vendor.marketingName,
       description: vendor.description,
       display_order: vendor.displayOrder,
       wallet_address: vendor.walletAddress,

--- a/apps/backend/src/api/general-settings/use-cases/create-vendor/index.test.ts
+++ b/apps/backend/src/api/general-settings/use-cases/create-vendor/index.test.ts
@@ -7,6 +7,7 @@ const mockedVendorRepository = mockVendorRepository()
 
 const mockedPayload = {
   name: 'Vendor Name',
+  marketing_name: 'Vendor Marketing Name',
   description: 'Vendor description',
   wallet_address: 'vendor_wallet_address',
   profile_image: 'https://vendor_profile_image.link',
@@ -14,6 +15,7 @@ const mockedPayload = {
 
 const newVendor = vendorFactory({
   name: mockedPayload.name,
+  marketingName: mockedPayload.marketing_name,
   description: mockedPayload.description,
   walletAddress: mockedPayload.wallet_address,
   profileImage: mockedPayload.profile_image,
@@ -40,6 +42,7 @@ describe('CreateVendor', () => {
     expect(result).toEqual({
       id: newVendor.vendorId,
       name: newVendor.name,
+      marketing_name: newVendor.marketingName,
       description: newVendor.description,
       is_active: newVendor.isActive,
       display_order: newVendor.displayOrder,

--- a/apps/backend/src/api/general-settings/use-cases/create-vendor/index.ts
+++ b/apps/backend/src/api/general-settings/use-cases/create-vendor/index.ts
@@ -28,6 +28,7 @@ export class CreateVendor extends UseCaseBase implements IUseCaseHttp<ResponseSc
     return {
       id: vendor.vendorId,
       name: vendor.name,
+      marketing_name: vendor.marketingName,
       description: vendor.description,
       is_active: vendor.isActive,
       display_order: vendor.displayOrder,
@@ -40,6 +41,7 @@ export class CreateVendor extends UseCaseBase implements IUseCaseHttp<ResponseSc
     const validatedData = this.validate(payload, RequestSchema)
     const vendor = {
       name: validatedData.name,
+      marketingName: validatedData.marketing_name,
       description: validatedData.description,
       isActive: validatedData.is_active,
       displayOrder: validatedData.display_order,

--- a/apps/backend/src/api/general-settings/use-cases/create-vendor/types.ts
+++ b/apps/backend/src/api/general-settings/use-cases/create-vendor/types.ts
@@ -5,6 +5,7 @@ import { vendorSchema } from 'api/core/utils/zod'
 
 export const RequestSchema = z.object({
   name: z.string(),
+  marketing_name: z.string().optional(),
   description: z.string().optional(),
   is_active: z.boolean().optional(),
   display_order: z.number().int().min(0).optional(),

--- a/apps/backend/src/api/general-settings/use-cases/get-vendors/index.test.ts
+++ b/apps/backend/src/api/general-settings/use-cases/get-vendors/index.test.ts
@@ -39,6 +39,7 @@ describe('GetVendors', () => {
       {
         id: vendor1.vendorId,
         name: vendor1.name,
+        marketing_name: vendor1.marketingName,
         description: vendor1.description,
         is_active: vendor1.isActive,
         display_order: vendor1.displayOrder,
@@ -48,6 +49,7 @@ describe('GetVendors', () => {
       {
         id: vendor2.vendorId,
         name: vendor2.name,
+        marketing_name: vendor2.marketingName,
         description: vendor2.description,
         is_active: vendor2.isActive,
         display_order: vendor2.displayOrder,

--- a/apps/backend/src/api/general-settings/use-cases/get-vendors/index.ts
+++ b/apps/backend/src/api/general-settings/use-cases/get-vendors/index.ts
@@ -27,6 +27,7 @@ export class GetVendors extends UseCaseBase implements IUseCaseHttp<ResponseSche
     return vendors.map(vendor => ({
       id: vendor.vendorId,
       name: vendor.name,
+      marketing_name: vendor.marketingName,
       description: vendor.description,
       is_active: vendor.isActive,
       display_order: vendor.displayOrder,

--- a/apps/backend/src/api/general-settings/use-cases/update-vendor/index.test.ts
+++ b/apps/backend/src/api/general-settings/use-cases/update-vendor/index.test.ts
@@ -37,6 +37,7 @@ describe('UpdateVendor', () => {
     const result = useCase.parseResponseVendor(mockedVendor)
     expect(result).toEqual({
       name: mockedVendor.name,
+      marketing_name: mockedVendor.marketingName,
       description: mockedVendor.description,
       is_active: mockedVendor.isActive,
       display_order: mockedVendor.displayOrder,

--- a/apps/backend/src/api/general-settings/use-cases/update-vendor/index.ts
+++ b/apps/backend/src/api/general-settings/use-cases/update-vendor/index.ts
@@ -28,6 +28,7 @@ export class UpdateVendor extends UseCaseBase implements IUseCaseHttp<ResponseSc
   parseResponseVendor(vendor: Vendor) {
     return {
       name: vendor.name,
+      marketing_name: vendor.marketingName,
       description: vendor.description,
       is_active: vendor.isActive,
       display_order: vendor.displayOrder,
@@ -40,6 +41,7 @@ export class UpdateVendor extends UseCaseBase implements IUseCaseHttp<ResponseSc
     const validatedData = this.validate(payload, RequestSchema)
     const updatedFields = {
       name: validatedData.name,
+      marketingName: validatedData.marketing_name,
       description: validatedData.description,
       isActive: validatedData.is_active,
       displayOrder: validatedData.display_order,

--- a/apps/backend/src/api/general-settings/use-cases/update-vendor/types.ts
+++ b/apps/backend/src/api/general-settings/use-cases/update-vendor/types.ts
@@ -6,6 +6,7 @@ import { vendorSchema } from 'api/core/utils/zod'
 export const RequestSchema = z.object({
   id: z.string(),
   name: z.string().optional(),
+  marketing_name: z.string().optional(),
   description: z.string().optional(),
   is_active: z.boolean().optional(),
   display_order: z.number().int().min(0).optional(),

--- a/apps/web/src/app/wallet/pages/home/index.tsx
+++ b/apps/web/src/app/wallet/pages/home/index.tsx
@@ -152,6 +152,7 @@ export const Home = () => {
       .map(vendor => ({
         imageUri: vendor.profile_image ?? 'unknown',
         name: vendor.name,
+        marketingName: vendor.marketing_name,
         description: vendor.description,
       }))
   }, [walletData?.vendors])

--- a/apps/web/src/app/wallet/services/wallet/types.ts
+++ b/apps/web/src/app/wallet/services/wallet/types.ts
@@ -42,6 +42,7 @@ export type GetWalletResult = IHTTPResponse<{
   vendors?: {
     id: string
     name: string
+    marketing_name?: string
     description?: string
     display_order: number
     wallet_address?: string

--- a/apps/web/src/components/organisms/vendor-card/index.tsx
+++ b/apps/web/src/components/organisms/vendor-card/index.tsx
@@ -3,10 +3,11 @@ import { Text } from '@stellar/design-system'
 type Props = {
   imageUri: string
   name: string
+  marketingName?: string
   description?: string
 }
 
-export const VendorCard = ({ imageUri, name, description }: Props): React.ReactNode => {
+export const VendorCard = ({ imageUri, name, marketingName, description }: Props): React.ReactNode => {
   return (
     <div>
       <div className="flex flex-col gap-4 p-4 rounded-lg bg-backgroundPrimary border border-borderPrimary">
@@ -17,7 +18,7 @@ export const VendorCard = ({ imageUri, name, description }: Props): React.ReactN
         <div className="flex flex-col gap-1">
           <div className="text-text">
             <Text as="p" size={'md'} weight="medium">
-              {name}
+              {marketingName ?? name}
             </Text>
           </div>
 


### PR DESCRIPTION
### What

- Adds `marketing_name` into `vendor` table

### Why

- Necessary due to splitting the responsibilities of `vendor` name into `name` AND `marketing_name`. Improving custom usage

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
