### PR TITLE
Fix(backend): options props overriding where conditions

### DIFF
--- a/apps/backend/src/api/core/services/otp/index.ts
+++ b/apps/backend/src/api/core/services/otp/index.ts
@@ -11,7 +11,12 @@ export default class OtpRepository extends SingletonBase implements OtpRepositor
   }
 
   async getOtpByCode(code: string, options?: FindOneOptions<Otp>): Promise<Otp | null> {
-    return OtpModel.findOne({ where: { code }, ...options })
+    const whereCondition = {
+      code,
+      ...options?.where,
+    }
+
+    return OtpModel.findOne({ ...options, where: whereCondition })
   }
 
   async createOtp(user: User, save?: boolean): Promise<Otp> {

--- a/apps/backend/src/api/core/services/user-product/index.ts
+++ b/apps/backend/src/api/core/services/user-product/index.ts
@@ -29,9 +29,9 @@ export default class UserProductRepository extends SingletonBase implements User
     options?: FindOneOptions<UserProduct>
   ): Promise<UserProduct[]> {
     const whereCondition = {
-      ...options?.where,
       user: { contractAddress: ILike(contractAddress) },
       product: { asset: { code: ILike(assetCode) } },
+      ...options?.where,
     }
 
     return UserProductModel.find({

--- a/apps/backend/src/api/core/services/user/index.ts
+++ b/apps/backend/src/api/core/services/user/index.ts
@@ -14,7 +14,12 @@ export default class UserRepository extends SingletonBase implements UserReposit
   }
 
   async getUserById(userId: string, options?: FindOneOptions<User>): Promise<User | null> {
-    return UserModel.findOne({ where: { userId: userId }, ...options })
+    const whereCondition = {
+      userId,
+      ...options?.where,
+    }
+
+    return UserModel.findOne({ ...options, where: whereCondition })
   }
 
   async getUserByToken(token: string): Promise<User | null> {
@@ -22,7 +27,12 @@ export default class UserRepository extends SingletonBase implements UserReposit
   }
 
   async getUserByEmail(email: string, options?: FindOneOptions<User>): Promise<User | null> {
-    return UserModel.findOne({ where: { email: ILike(email) }, ...options })
+    const whereCondition = {
+      email: ILike(email),
+      ...options?.where,
+    }
+
+    return UserModel.findOne({ ...options, where: whereCondition })
   }
 
   async getUserByContractAddress(contractAddress: string): Promise<User | null> {

--- a/apps/backend/src/api/core/services/vendor/index.ts
+++ b/apps/backend/src/api/core/services/vendor/index.ts
@@ -18,7 +18,12 @@ export default class VendorRepository extends SingletonBase implements VendorRep
   }
 
   async getVendorByWalletAddress(walletAddress: string, options?: FindOneOptions<Vendor>): Promise<Vendor | null> {
-    return VendorModel.findOne({ where: { walletAddress: ILike(walletAddress) }, ...options })
+    const whereCondition = {
+      walletAddress: ILike(walletAddress),
+      ...options?.where,
+    }
+
+    return VendorModel.findOne({ ...options, where: whereCondition })
   }
 
   async createVendor(


### PR DESCRIPTION
### What

- The way `options` was being passed as props and set on Typeorm methods was overriding the `where` conditions

### Why

- Causing unexpected search return behaviors across the app

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
