### PR TITLE
Update invite screen

### DIFF
--- a/apps/web/src/app/auth/pages/invite/index.tsx
+++ b/apps/web/src/app/auth/pages/invite/index.tsx
@@ -2,6 +2,8 @@ import { useSuspenseQuery } from '@tanstack/react-query'
 import { useNavigate } from '@tanstack/react-router'
 import { useEffect, useMemo, useState } from 'react'
 
+import { useTheme } from 'src/config/theme/provider'
+
 import { InviteTemplate } from './template'
 import { useCreateWallet } from '../../queries/use-create-wallet'
 import { getInvitationInfoOptions } from '../../queries/use-get-invitation-info'
@@ -12,7 +14,9 @@ import { AuthPagesPath } from '../../routes/types'
 export const Invite = () => {
   const search = inviteRoute.useSearch()
   const navigate = useNavigate()
+  const { onboardingStyleVariant } = useTheme()
   const [isRedirecting, setIsRedirecting] = useState(false)
+  const [hasStarted, setHasStarted] = useState(false)
 
   const createWallet = useCreateWallet({
     onSuccess: () => {
@@ -28,6 +32,10 @@ export const Invite = () => {
 
   const isReturningUser = useMemo(() => getInvitationInfo.data.status === 'SUCCESS', [getInvitationInfo.data.status])
   const email = useMemo(() => getInvitationInfo.data.email, [getInvitationInfo.data.email])
+  const showTapToStart = useMemo(
+    () => onboardingStyleVariant === 'stellar-house' && !isReturningUser && !hasStarted,
+    [hasStarted, isReturningUser, onboardingStyleVariant]
+  )
 
   const handleCreateWallet = () => {
     if (!search.token) return navigate({ to: AuthPagesPath.INVITE_RESEND })
@@ -45,16 +53,23 @@ export const Invite = () => {
     navigate({ to: AuthPagesPath.RECOVER })
   }
 
-  // Reset redirecting state when component mounts
+  const handleGetStarted = () => {
+    setHasStarted(true)
+  }
+
+  // Reset transient invite page state when the token changes.
   useEffect(() => {
     setIsRedirecting(false)
-  }, [])
+    setHasStarted(false)
+  }, [search.token])
 
   return (
     <InviteTemplate
       isReturningUser={isReturningUser}
       isCreatingWallet={createWallet.isPending || isRedirecting}
       isLoggingIn={logIn.isPending || isRedirecting}
+      showTapToStart={showTapToStart}
+      onGetStarted={handleGetStarted}
       onCreateWallet={handleCreateWallet}
       onLogIn={handleLogIn}
       onForgotPassword={handleForgotPassword}

--- a/apps/web/src/app/auth/pages/invite/template.tsx
+++ b/apps/web/src/app/auth/pages/invite/template.tsx
@@ -14,6 +14,8 @@ type Props = {
   isReturningUser: boolean
   isCreatingWallet: boolean
   isLoggingIn: boolean
+  showTapToStart: boolean
+  onGetStarted: () => void
   onCreateWallet: () => void
   onLogIn: () => void
   onForgotPassword: () => void
@@ -23,11 +25,14 @@ export const InviteTemplate = ({
   isReturningUser,
   isCreatingWallet,
   isLoggingIn,
+  showTapToStart,
+  onGetStarted,
   onCreateWallet,
   onLogIn,
   onForgotPassword,
 }: Props) => {
   const { onboardingStyleVariant } = useTheme()
+  const showStellarHouseSubtitle = isReturningUser || showTapToStart
 
   const hasAddendum = import.meta.env.VITE_ADDENDUM_URL && import.meta.env.VITE_ADDENDUM_URL.trim() !== ''
   const config = isReturningUser
@@ -110,7 +115,11 @@ export const InviteTemplate = ({
             ) : null}
             <img src={a('onboardingBrandLogo')} alt="Brand Logo" />
 
-            <Text addlClassName="text-brownishSecondary text-center" as="h3" size="md">
+            <Text
+              addlClassName={clsx('text-brownishSecondary text-center', !showStellarHouseSubtitle && 'invisible')}
+              as="h3"
+              size="md"
+            >
               {mapTextWithLinks(config.subtitle)}
             </Text>
           </div>
@@ -145,6 +154,31 @@ export const InviteTemplate = ({
     )
   }
 
+  if (showTapToStart) {
+    return (
+      <div className="h-full">
+        <OnboardingBackgroundImage backgroundPosition="center" />
+        <button
+          type="button"
+          className="relative flex h-full w-full flex-col bg-transparent px-8 text-left"
+          onClick={onGetStarted}
+        >
+          <div className="mt-[calc(100svh-71svh)] flex flex-col">
+            <Header />
+          </div>
+
+          <Typography
+            className="absolute inset-x-0 bottom-[10%] text-center text-md font-semibold text-brownish"
+            variant={TypographyVariant.label}
+            fontFamily={TypographyFontFamily.lora}
+          >
+            {c('inviteTapToStart')}
+          </Typography>
+        </button>
+      </div>
+    )
+  }
+
   return (
     <div>
       <OnboardingBackgroundImage
@@ -167,7 +201,9 @@ export const InviteTemplate = ({
         {config.disclaimer && (
           <div className="mt-2 text-center">
             <Text
-              addlClassName={onboardingStyleVariant === 'stellar-house' ? 'text-whitish' : 'text-textSecondary'}
+              addlClassName={
+                onboardingStyleVariant === 'stellar-house' ? 'text-brownishSecondary' : 'text-textSecondary'
+              }
               as="span"
               size="xs"
             >

--- a/apps/web/src/app/core/utils/map-text-with-links/index.tsx
+++ b/apps/web/src/app/core/utils/map-text-with-links/index.tsx
@@ -3,14 +3,14 @@ export const mapTextWithLinks = (items: { text: string; link?: string; removeBla
     const blankSpace = `${index < items.length - 1 && !subtitle.removeBlankSpace ? ' ' : ''}`
 
     return subtitle.link ? (
-      <span>
-        <a className="underline" href={subtitle.link} target="_blank" rel="noopener noreferrer">
+      <span key={`${subtitle.text}-${index}`}>
+        <a className="[color:inherit] underline" href={subtitle.link} target="_blank" rel="noopener noreferrer">
           {subtitle.text}
         </a>
         {blankSpace}
       </span>
     ) : (
-      <span>
+      <span key={`${subtitle.text}-${index}`}>
         {subtitle.text}
         {blankSpace}
       </span>

--- a/apps/web/src/config/content.example.json
+++ b/apps/web/src/config/content.example.json
@@ -11,6 +11,7 @@
   "inviteOptionADisclaimerText6": "Addendum",
   "inviteSubtitle": "Meridian Pay is your Stellar smart wallet for event payments, NFTs, and surprises.",
   "inviteSubtitleLink": "Policy & Terms of Use",
+  "inviteTapToStart": "Tap anywhere to get started",
   "createAWallet": "Create a wallet",
   "logIn": "Log in",
   "forgotPassword": "Forgot password?",


### PR DESCRIPTION
### What

Add a new "Tap anywhere to get started" screen when user is coming from the invite.

<img width="418" height="918" alt="Screenshot 2026-03-16 at 4 29 27 PM" src="https://github.com/user-attachments/assets/3d2db33d-e443-4019-bc39-b737f3a7d701" />
<img width="419" height="922" alt="Screenshot 2026-03-16 at 4 29 31 PM" src="https://github.com/user-attachments/assets/d2101772-2881-4211-9bdd-9468bf66ed42" />


### Why

N/A

### Checklist

#### PR Structure

- [ ] It is not possible to break this PR down into smaller PRs.
- [ ] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [ ] This is not a breaking change.
- [ ] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
