### PR TITLE
Resolve airdrop recipients from SDP disbursement

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,9 +123,13 @@ The backend includes airdrop functionality through the embedded wallets API for 
 ### Setup
 
 1. Deploy an airdrop contract (see [contracts/](./contracts))
-2. Generate proofs: `npm run --workspace=scripts generate-proofs`
-3. Upload proofs: `npm run --workspace=scripts upload-proofs`
-4. Get airdrop options: `GET /api/embedded-wallets/airdrop/options`
-5. Complete airdrop claim: `POST /api/embedded-wallets/airdrop/complete`
+2. Resolve recipients: if they come from an SDP disbursement, run
+   `npm run --workspace=scripts prepare-airdrop` (see
+   [contracts/airdrop/README.md](./contracts/airdrop/README.md#recipients-file))
+   instead of building `recipients.txt` by hand
+3. Generate proofs: `npm run --workspace=scripts generate-proofs`
+4. Upload proofs: `npm run --workspace=scripts upload-proofs`
+5. Get airdrop options: `GET /api/embedded-wallets/airdrop/options`
+6. Complete airdrop claim: `POST /api/embedded-wallets/airdrop/complete`
 
 ---

--- a/contracts/airdrop/README.md
+++ b/contracts/airdrop/README.md
@@ -51,6 +51,24 @@ GCJVXKQVGXSTRGAK7WDPUPH6LGRQFVMUJ6XJMTQZX7LGMVKVGVQF7QTJ
 CAZDTOPFCY47C62SH7K5SXIVV46CMFDO3L7T4V42VK6VHGN3LUBY65ZE
 ```
 
+If your recipients come from an SDP disbursement, don't build this file by
+hand — it requires manually cross-referencing SDP's recipient emails against
+separately-computed contract addresses, which is easy to get wrong. Generate
+it instead with:
+
+```bash
+SDP_API_KEY=<key> npm run --workspace=scripts prepare-airdrop -- \
+  --sdp-url <sdp-base-url> \
+  --disbursement-id <disbursement-id> \
+  --distribution-account <distribution-account-public-key> \
+  --network <testnet|mainnet> \
+  --amount <stroops-per-recipient> \
+  --output recipients.txt
+```
+
+This pulls the disbursement's receivers directly from SDP and derives each
+contract address locally.
+
 #### Environment Variables
 
 Also, we're assuming these env variables are set:

--- a/scripts/deploy-airdrop.mjs
+++ b/scripts/deploy-airdrop.mjs
@@ -4,6 +4,7 @@ import { exec } from 'child_process';
 import { promisify } from 'util';
 import { generateProofsFromFile } from './generate-proofs.mjs';
 import { uploadProofsToDB } from './upload-proofs-to-db.mjs';
+import { resolveNetworkPassphrase } from './helpers/contract-address.mjs';
 
 const execAsync = promisify(exec);
 
@@ -73,9 +74,7 @@ const {
     'database-url': databaseUrl
 } = argv;
 
-const networkPassphrase = network === 'mainnet' 
-    ? 'Public Global Stellar Network ; September 2015'
-    : 'Test SDF Network ; September 2015';
+const networkPassphrase = resolveNetworkPassphrase(network);
 
 
 async function deployContract(rootHash) {

--- a/scripts/helpers/amount.mjs
+++ b/scripts/helpers/amount.mjs
@@ -8,13 +8,25 @@ export function assetAmountToStroops(decimalAmount) {
     const trimmed = String(decimalAmount).trim();
     const isNegative = trimmed.startsWith('-');
     const unsigned = isNegative ? trimmed.slice(1) : trimmed;
-    const [wholePart = '', fractionalPart = ''] = unsigned.split('.');
+    const parts = unsigned.split('.');
+    if (parts.length > 2) {
+        throw new Error(`Invalid decimal amount: ${decimalAmount}`);
+    }
+    const [wholePart = '', fractionalPart = ''] = parts;
 
-    if (!/^\d*$/.test(wholePart) || !/^\d*$/.test(fractionalPart)) {
+    // Stellar amounts have at most 7 decimal places (stroops precision) — reject
+    // anything more precise instead of silently truncating it to fit. Also
+    // reject "" / "." / "-": at least one digit must be present somewhere.
+    if (
+        !/^\d*$/.test(wholePart) ||
+        !/^\d*$/.test(fractionalPart) ||
+        fractionalPart.length > 7 ||
+        (wholePart === '' && fractionalPart === '')
+    ) {
         throw new Error(`Invalid decimal amount: ${decimalAmount}`);
     }
 
-    const fractionalStroops = fractionalPart.padEnd(7, '0').slice(0, 7);
+    const fractionalStroops = fractionalPart.padEnd(7, '0');
     const stroops = BigInt(wholePart || '0') * STROOPS_PER_UNIT + BigInt(fractionalStroops || '0');
 
     return isNegative ? -stroops : stroops;

--- a/scripts/helpers/amount.mjs
+++ b/scripts/helpers/amount.mjs
@@ -1,0 +1,21 @@
+const STROOPS_PER_UNIT = 10000000n; // 1 unit of any Stellar asset = 10^7 stroops
+
+// Converts a decimal asset-unit amount, as returned by SDP's payment records
+// (e.g. "0.1" XLM), into an integer stroops amount. Uses string/BigInt
+// arithmetic instead of Number() — floating point would silently misround
+// fractional amounts and break the stroops comparison against --amount.
+export function assetAmountToStroops(decimalAmount) {
+    const trimmed = String(decimalAmount).trim();
+    const isNegative = trimmed.startsWith('-');
+    const unsigned = isNegative ? trimmed.slice(1) : trimmed;
+    const [wholePart = '', fractionalPart = ''] = unsigned.split('.');
+
+    if (!/^\d*$/.test(wholePart) || !/^\d*$/.test(fractionalPart)) {
+        throw new Error(`Invalid decimal amount: ${decimalAmount}`);
+    }
+
+    const fractionalStroops = fractionalPart.padEnd(7, '0').slice(0, 7);
+    const stroops = BigInt(wholePart || '0') * STROOPS_PER_UNIT + BigInt(fractionalStroops || '0');
+
+    return isNegative ? -stroops : stroops;
+}

--- a/scripts/helpers/amount.test.mjs
+++ b/scripts/helpers/amount.test.mjs
@@ -1,0 +1,32 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { assetAmountToStroops } from './amount.mjs';
+
+test('converts valid decimal amounts to stroops', () => {
+    const cases = [
+        ['0.1', 1000000n],
+        ['.1', 1000000n],
+        ['10', 100000000n],
+        ['0.0000001', 1n],
+        ['1.0000001', 10000001n],
+        ['0', 0n],
+        ['-0.1', -1000000n]
+    ];
+
+    for (const [input, expected] of cases) {
+        assert.equal(assetAmountToStroops(input), expected, `assetAmountToStroops(${JSON.stringify(input)})`);
+    }
+});
+
+test('rejects malformed or over-precise decimal amounts instead of truncating them', () => {
+    const cases = ['1.2.3', '0.12345678', '1..2', '.', '1.2.', 'abc', '', '-', '-.'];
+
+    for (const input of cases) {
+        assert.throws(
+            () => assetAmountToStroops(input),
+            /Invalid decimal amount/,
+            `assetAmountToStroops(${JSON.stringify(input)}) should throw`
+        );
+    }
+});

--- a/scripts/helpers/contract-address.mjs
+++ b/scripts/helpers/contract-address.mjs
@@ -1,0 +1,39 @@
+import { Address, StrKey, hash, xdr } from '@stellar/stellar-sdk';
+
+const NETWORK_PASSPHRASES = {
+    testnet: 'Test SDF Network ; September 2015',
+    mainnet: 'Public Global Stellar Network ; September 2015'
+};
+
+export function resolveNetworkPassphrase(network) {
+    const passphrase = NETWORK_PASSPHRASES[network];
+    if (!passphrase) {
+        throw new Error(`Unknown network: ${network}. Expected one of: ${Object.keys(NETWORK_PASSPHRASES).join(', ')}`);
+    }
+    return passphrase;
+}
+
+// Mirrors stellar-disbursement-platform-backend's internal/utils/contract_salt.go,
+// so the salt computed here always matches the one SDP used to deploy the wallet.
+export function computeSaltFromEmail(email) {
+    const normalized = email.trim().toLowerCase();
+    return hash(Buffer.from(`EMAIL:${normalized}`, 'utf8'));
+}
+
+// Mirrors stellar-disbursement-platform-backend's internal/utils/contract_address.go
+// (CalculateContractAddressFromReceiver). Computable entirely offline: no SDP or
+// wallet-backend call needed, and no dependency on the wallet having been deployed yet.
+export function computeContractAddressFromEmail(email, distributionAccountPublicKey, networkPassphrase) {
+    const salt = computeSaltFromEmail(email);
+    const address = new Address(distributionAccountPublicKey).toScAddress();
+
+    const preimage = xdr.HashIdPreimage.envelopeTypeContractId(new xdr.HashIdPreimageContractId({
+        networkId: hash(Buffer.from(networkPassphrase, 'utf8')),
+        contractIdPreimage: xdr.ContractIdPreimage.contractIdPreimageFromAddress(new xdr.ContractIdPreimageFromAddress({
+            address,
+            salt
+        }))
+    }));
+
+    return StrKey.encodeContract(hash(preimage.toXDR()));
+}

--- a/scripts/helpers/contract-address.test.mjs
+++ b/scripts/helpers/contract-address.test.mjs
@@ -1,0 +1,40 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { computeContractAddressFromEmail, computeSaltFromEmail, resolveNetworkPassphrase } from './contract-address.mjs';
+
+// Golden values cross-checked against stellar-disbursement-platform-backend's
+// actual Go implementation (internal/utils/contract_salt.go +
+// contract_address.go), by running both side by side for the same inputs. If
+// this test ever fails after touching this file, the JS port has drifted from
+// SDP's algorithm and every address this script computes would be wrong.
+test("matches SDP's Go implementation for a known email/account/network", () => {
+    const email = 'test.user@example.com';
+    const distributionAccount = 'GCUZ37M45SEMGYFYYZE7IBTS3ISKGPDLFRNHS73ORSTMNYM64NLEQO76';
+    const networkPassphrase = resolveNetworkPassphrase('testnet');
+
+    const salt = computeSaltFromEmail(email);
+    assert.equal(
+        salt.toString('hex'),
+        '3d1fc1f3df634af002628b24cb96facc565364ce38c65c2fc326be4b12b1f8fd'
+    );
+
+    const address = computeContractAddressFromEmail(email, distributionAccount, networkPassphrase);
+    assert.equal(address, 'CC3LS4WGLR5UPFM6R2ZLWITZ5H5FFZAJ46AY3SBOB5FMYUSM2UCPAN3Y');
+});
+
+test('normalizes email case and surrounding whitespace before salting', () => {
+    const distributionAccount = 'GCUZ37M45SEMGYFYYZE7IBTS3ISKGPDLFRNHS73ORSTMNYM64NLEQO76';
+    const networkPassphrase = resolveNetworkPassphrase('testnet');
+
+    const base = computeContractAddressFromEmail('alice@example.com', distributionAccount, networkPassphrase);
+    const upper = computeContractAddressFromEmail('Alice@Example.com', distributionAccount, networkPassphrase);
+    const padded = computeContractAddressFromEmail('  alice@example.com  ', distributionAccount, networkPassphrase);
+
+    assert.equal(upper, base);
+    assert.equal(padded, base);
+});
+
+test('rejects unknown network names', () => {
+    assert.throws(() => resolveNetworkPassphrase('devnet'), /Unknown network/);
+});

--- a/scripts/helpers/mask-email.mjs
+++ b/scripts/helpers/mask-email.mjs
@@ -1,0 +1,8 @@
+// Masks an email for terminal/CI logs — keeps enough to spot which receiver a
+// warning is about without printing the full address (PII) into logs that may
+// be retained (CI output, shared terminals), including on mainnet runs.
+export function maskEmail(email) {
+    const [localPart = '', domain = ''] = String(email).split('@');
+    const visible = localPart.slice(0, 1) || '*';
+    return `${visible}***@${domain}`;
+}

--- a/scripts/helpers/sdp-client.mjs
+++ b/scripts/helpers/sdp-client.mjs
@@ -13,9 +13,9 @@ export async function fetchDisbursementReceivers({ sdpUrl, apiKey, disbursementI
     const baseUrl = sdpUrl.replace(/\/$/, '');
     const receivers = [];
     let page = 1;
-    let total = Infinity;
+    let total = null;
 
-    while (receivers.length < total) {
+    while (total === null || receivers.length < total) {
         const url = `${baseUrl}/disbursements/${disbursementId}/receivers?page=${page}&page_limit=${pageLimit}`;
         const response = await fetch(url, {
             headers: {
@@ -31,12 +31,26 @@ export async function fetchDisbursementReceivers({ sdpUrl, apiKey, disbursementI
 
         const body = await response.json();
         const pageData = Array.isArray(body.data) ? body.data : [];
-        if (pageData.length === 0) {
-            break; // defensive: avoid looping forever if `total` is ever missing/wrong
+
+        if (typeof body.pagination?.total === 'number') {
+            total = body.pagination.total;
+        } else if (total === null) {
+            total = receivers.length + pageData.length;
+        }
+
+        // An empty page is only expected once we've already collected `total`
+        // receivers (checked by the while condition above). Getting one before
+        // that means SDP's data changed or is inconsistent between requests —
+        // abort loudly instead of silently writing a partial recipients list.
+        if (pageData.length === 0 && receivers.length < total) {
+            throw new Error(
+                `SDP returned an empty page (page=${page}) before reaching the reported total ` +
+                `(${receivers.length}/${total} receivers collected so far). Aborting instead of ` +
+                'writing an incomplete recipients list.'
+            );
         }
 
         receivers.push(...pageData);
-        total = body.pagination?.total ?? receivers.length;
         page += 1;
     }
 

--- a/scripts/helpers/sdp-client.mjs
+++ b/scripts/helpers/sdp-client.mjs
@@ -4,12 +4,19 @@ const DEFAULT_PAGE_LIMIT = 200;
 // DisbursementHandler.GetDisbursementReceivers. Auth accepts a static API key
 // (Authorization: Bearer <key>) via middleware.APIKeyOrJWTAuthenticate, same
 // pattern already used for SDP_EMBEDDED_WALLETS_API_KEY elsewhere in this repo.
+//
+// Paginates by tracking `page`/`page_limit` against the response's
+// `pagination.total`, instead of following `pagination.next`: the server builds
+// that URL from the request it received, which can point at a host this script
+// cannot reach when SDP sits behind a reverse proxy (as it does in stg/dev).
 export async function fetchDisbursementReceivers({ sdpUrl, apiKey, disbursementId, pageLimit = DEFAULT_PAGE_LIMIT }) {
     const baseUrl = sdpUrl.replace(/\/$/, '');
-    let url = `${baseUrl}/disbursements/${disbursementId}/receivers?page=1&page_limit=${pageLimit}`;
     const receivers = [];
+    let page = 1;
+    let total = Infinity;
 
-    while (url) {
+    while (receivers.length < total) {
+        const url = `${baseUrl}/disbursements/${disbursementId}/receivers?page=${page}&page_limit=${pageLimit}`;
         const response = await fetch(url, {
             headers: {
                 Authorization: `Bearer ${apiKey}`,
@@ -23,10 +30,14 @@ export async function fetchDisbursementReceivers({ sdpUrl, apiKey, disbursementI
         }
 
         const body = await response.json();
-        const page = Array.isArray(body.data) ? body.data : [];
-        receivers.push(...page);
+        const pageData = Array.isArray(body.data) ? body.data : [];
+        if (pageData.length === 0) {
+            break; // defensive: avoid looping forever if `total` is ever missing/wrong
+        }
 
-        url = body.pagination?.next || null;
+        receivers.push(...pageData);
+        total = body.pagination?.total ?? receivers.length;
+        page += 1;
     }
 
     return receivers;

--- a/scripts/helpers/sdp-client.mjs
+++ b/scripts/helpers/sdp-client.mjs
@@ -1,0 +1,33 @@
+const DEFAULT_PAGE_LIMIT = 200;
+
+// GET /disbursements/{id}/receivers, per stellar-disbursement-platform-backend's
+// DisbursementHandler.GetDisbursementReceivers. Auth accepts a static API key
+// (Authorization: Bearer <key>) via middleware.APIKeyOrJWTAuthenticate, same
+// pattern already used for SDP_EMBEDDED_WALLETS_API_KEY elsewhere in this repo.
+export async function fetchDisbursementReceivers({ sdpUrl, apiKey, disbursementId, pageLimit = DEFAULT_PAGE_LIMIT }) {
+    const baseUrl = sdpUrl.replace(/\/$/, '');
+    let url = `${baseUrl}/disbursements/${disbursementId}/receivers?page=1&page_limit=${pageLimit}`;
+    const receivers = [];
+
+    while (url) {
+        const response = await fetch(url, {
+            headers: {
+                Authorization: `Bearer ${apiKey}`,
+                Accept: 'application/json'
+            }
+        });
+
+        if (!response.ok) {
+            const body = await response.text().catch(() => '');
+            throw new Error(`SDP request failed (${response.status} ${response.statusText}) for ${url}: ${body}`);
+        }
+
+        const body = await response.json();
+        const page = Array.isArray(body.data) ? body.data : [];
+        receivers.push(...page);
+
+        url = body.pagination?.next || null;
+    }
+
+    return receivers;
+}

--- a/scripts/helpers/sdp-client.mjs
+++ b/scripts/helpers/sdp-client.mjs
@@ -1,15 +1,28 @@
 const DEFAULT_PAGE_LIMIT = 200;
+const DEFAULT_TIMEOUT_MS = 15000;
 
 // GET /disbursements/{id}/receivers, per stellar-disbursement-platform-backend's
-// DisbursementHandler.GetDisbursementReceivers. Auth accepts a static API key
-// (Authorization: Bearer <key>) via middleware.APIKeyOrJWTAuthenticate, same
-// pattern already used for SDP_EMBEDDED_WALLETS_API_KEY elsewhere in this repo.
+// DisbursementHandler.GetDisbursementReceivers. The auth middleware
+// (internal/serve/middleware/api_keys_middleware.go) splits the Authorization
+// header on a single space and validates whatever comes after it (or the whole
+// header, if there's no space) as an SDP_ API key — so `Bearer <key>` works
+// fine here, even though SDP_EMBEDDED_WALLETS_API_KEY elsewhere in this repo
+// sends the raw key with no "Bearer " prefix instead; the two are not the same
+// convention, just both accepted by this particular middleware.
 //
 // Paginates by tracking `page`/`page_limit` against the response's
 // `pagination.total`, instead of following `pagination.next`: the server builds
 // that URL from the request it received, which can point at a host this script
 // cannot reach when SDP sits behind a reverse proxy (as it does in stg/dev).
-export async function fetchDisbursementReceivers({ sdpUrl, apiKey, disbursementId, pageLimit = DEFAULT_PAGE_LIMIT }) {
+export async function fetchDisbursementReceivers({
+    sdpUrl,
+    apiKey,
+    disbursementId,
+    pageLimit = DEFAULT_PAGE_LIMIT,
+    timeoutMs = DEFAULT_TIMEOUT_MS
+}) {
+    assertSecureUrl(sdpUrl);
+
     const baseUrl = sdpUrl.replace(/\/$/, '');
     const receivers = [];
     let page = 1;
@@ -17,12 +30,19 @@ export async function fetchDisbursementReceivers({ sdpUrl, apiKey, disbursementI
 
     while (total === null || receivers.length < total) {
         const url = `${baseUrl}/disbursements/${disbursementId}/receivers?page=${page}&page_limit=${pageLimit}`;
-        const response = await fetch(url, {
-            headers: {
-                Authorization: `Bearer ${apiKey}`,
-                Accept: 'application/json'
-            }
-        });
+
+        let response;
+        try {
+            response = await fetch(url, {
+                headers: {
+                    Authorization: `Bearer ${apiKey}`,
+                    Accept: 'application/json'
+                },
+                signal: AbortSignal.timeout(timeoutMs)
+            });
+        } catch (error) {
+            throw new Error(`SDP request to ${url} timed out or failed after ${timeoutMs}ms: ${error.message}`);
+        }
 
         if (!response.ok) {
             const body = await response.text().catch(() => '');
@@ -32,11 +52,17 @@ export async function fetchDisbursementReceivers({ sdpUrl, apiKey, disbursementI
         const body = await response.json();
         const pageData = Array.isArray(body.data) ? body.data : [];
 
-        if (typeof body.pagination?.total === 'number') {
-            total = body.pagination.total;
-        } else if (total === null) {
-            total = receivers.length + pageData.length;
+        // Real SDP always serializes pagination.total (no `omitempty`), even when
+        // it's 0. Requiring it — rather than guessing from the current page's
+        // size — avoids silently capping the result at whatever page 1 happened
+        // to contain.
+        if (typeof body.pagination?.total !== 'number') {
+            throw new Error(
+                `SDP response for page=${page} is missing a numeric pagination.total — ` +
+                'cannot safely determine when all receivers have been fetched.'
+            );
         }
+        total = body.pagination.total;
 
         // An empty page is only expected once we've already collected `total`
         // receivers (checked by the while condition above). Getting one before
@@ -55,4 +81,15 @@ export async function fetchDisbursementReceivers({ sdpUrl, apiKey, disbursementI
     }
 
     return receivers;
+}
+
+function assertSecureUrl(sdpUrl) {
+    const parsed = new URL(sdpUrl);
+    const isLocal = parsed.hostname === 'localhost' || parsed.hostname === '127.0.0.1';
+    if (parsed.protocol !== 'https:' && !isLocal) {
+        throw new Error(
+            `Refusing to send the SDP API key over a non-HTTPS URL: ${sdpUrl}. ` +
+            'Use https:// (localhost is exempt for local testing).'
+        );
+    }
 }

--- a/scripts/helpers/sdp-client.test.mjs
+++ b/scripts/helpers/sdp-client.test.mjs
@@ -1,0 +1,96 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { fetchDisbursementReceivers } from './sdp-client.mjs';
+
+function jsonResponse(body) {
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+    });
+}
+
+test('fetches every page until the reported total is reached', async (t) => {
+    const requestUrls = [];
+    let requestHeaders;
+    t.mock.method(globalThis, 'fetch', async (url, options) => {
+        requestUrls.push(url);
+        requestHeaders = options.headers;
+        const page = Number(new URL(url).searchParams.get('page'));
+        if (page === 1) {
+            return jsonResponse({
+                data: [{ id: 'r1', email: 'a@example.com' }, { id: 'r2', email: 'b@example.com' }],
+                pagination: { total: 3 }
+            });
+        }
+        return jsonResponse({
+            data: [{ id: 'r3', email: 'c@example.com' }],
+            pagination: { total: 3 }
+        });
+    });
+
+    const receivers = await fetchDisbursementReceivers({
+        sdpUrl: 'https://sdp.example.com',
+        apiKey: 'test-key',
+        disbursementId: 'disb-1'
+    });
+
+    assert.deepEqual(receivers.map(r => r.id), ['r1', 'r2', 'r3']);
+    assert.equal(requestUrls.length, 2);
+    assert.equal(requestHeaders.Authorization, 'Bearer test-key');
+});
+
+test('returns an empty list for a disbursement with zero receivers', async (t) => {
+    t.mock.method(globalThis, 'fetch', async () => jsonResponse({ data: [], pagination: { total: 0 } }));
+
+    const receivers = await fetchDisbursementReceivers({
+        sdpUrl: 'https://sdp.example.com',
+        apiKey: 'test-key',
+        disbursementId: 'disb-empty'
+    });
+
+    assert.deepEqual(receivers, []);
+});
+
+test('aborts when an empty page arrives before the reported total', async (t) => {
+    t.mock.method(globalThis, 'fetch', async (url) => {
+        const page = Number(new URL(url).searchParams.get('page'));
+        if (page === 1) {
+            return jsonResponse({ data: [{ id: 'r1', email: 'a@example.com' }], pagination: { total: 3 } });
+        }
+        return jsonResponse({ data: [], pagination: { total: 3 } });
+    });
+
+    await assert.rejects(
+        () => fetchDisbursementReceivers({ sdpUrl: 'https://sdp.example.com', apiKey: 'k', disbursementId: 'd' }),
+        /empty page/
+    );
+});
+
+test('throws when pagination.total is missing or not a number', async (t) => {
+    t.mock.method(globalThis, 'fetch', async () => jsonResponse({ data: [{ id: 'r1', email: 'a@example.com' }] }));
+
+    await assert.rejects(
+        () => fetchDisbursementReceivers({ sdpUrl: 'https://sdp.example.com', apiKey: 'k', disbursementId: 'd' }),
+        /missing a numeric pagination.total/
+    );
+});
+
+test('rejects a non-HTTPS sdpUrl', async () => {
+    await assert.rejects(
+        () => fetchDisbursementReceivers({ sdpUrl: 'http://sdp.example.com', apiKey: 'k', disbursementId: 'd' }),
+        /non-HTTPS/
+    );
+});
+
+test('allows http for localhost', async (t) => {
+    t.mock.method(globalThis, 'fetch', async () => jsonResponse({ data: [], pagination: { total: 0 } }));
+
+    const receivers = await fetchDisbursementReceivers({
+        sdpUrl: 'http://localhost:4000',
+        apiKey: 'k',
+        disbursementId: 'd'
+    });
+
+    assert.deepEqual(receivers, []);
+});

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "test": "node --test helpers/*.test.mjs",
     "prepare-airdrop": "node prepare-airdrop.mjs",
     "generate-proofs": "node generate-proofs.mjs",
     "upload-proofs": "node upload-proofs-to-db.mjs",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,6 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
+    "prepare-airdrop": "node prepare-airdrop.mjs",
     "generate-proofs": "node generate-proofs.mjs",
     "upload-proofs": "node upload-proofs-to-db.mjs",
     "deploy-airdrop": "node deploy-airdrop.mjs",

--- a/scripts/package.json
+++ b/scripts/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "test": "node --test helpers/*.test.mjs",
+    "test": "node --test *.test.mjs helpers/*.test.mjs",
     "prepare-airdrop": "node prepare-airdrop.mjs",
     "generate-proofs": "node generate-proofs.mjs",
     "upload-proofs": "node upload-proofs-to-db.mjs",

--- a/scripts/prepare-airdrop.mjs
+++ b/scripts/prepare-airdrop.mjs
@@ -5,6 +5,7 @@ import { hideBin } from 'yargs/helpers';
 
 import { fetchDisbursementReceivers } from './helpers/sdp-client.mjs';
 import { computeContractAddressFromEmail, resolveNetworkPassphrase } from './helpers/contract-address.mjs';
+import { assetAmountToStroops } from './helpers/amount.mjs';
 import { logStep, logSuccess, logWarning, logError, logInfo } from './helpers/logs.mjs';
 
 // Resolves an SDP disbursement's recipients (by email) into the contract addresses
@@ -44,9 +45,13 @@ export async function resolveAirdropAddresses({
         }
         seenEmails.add(normalizedEmail);
 
-        const paymentAmount = receiver.payment?.amount;
-        if (expectedAmount != null && paymentAmount != null && Number(paymentAmount) !== Number(expectedAmount)) {
-            amountMismatches.push({ email, expected: expectedAmount, actual: paymentAmount });
+        // SDP reports payment.amount in decimal asset units (e.g. "0.1" XLM), while
+        // --amount and the rest of the airdrop pipeline use stroops — convert before comparing.
+        const paymentAmountStroops = receiver.payment?.amount != null
+            ? assetAmountToStroops(receiver.payment.amount)
+            : null;
+        if (expectedAmount != null && paymentAmountStroops != null && paymentAmountStroops !== BigInt(expectedAmount)) {
+            amountMismatches.push({ email, expected: expectedAmount, actual: paymentAmountStroops.toString() });
         }
 
         emails.push(email);
@@ -73,15 +78,10 @@ export async function resolveAirdropAddresses({
 
 async function main() {
     const argv = await yargs(hideBin(process.argv))
-        .usage('Usage: $0 --sdp-url <url> --sdp-api-key <key> --disbursement-id <id> --distribution-account <G...> --network <testnet|mainnet> [--amount <number>] [--output <path>]')
+        .usage('Usage: SDP_API_KEY=<key> $0 --sdp-url <url> --disbursement-id <id> --distribution-account <G...> --network <testnet|mainnet> [--amount <number>] [--output <path>]')
         .option('sdp-url', {
             type: 'string',
             description: 'Base URL of the SDP backend API',
-            demandOption: true
-        })
-        .option('sdp-api-key', {
-            type: 'string',
-            description: 'SDP API key with permission to read disbursement receivers',
             demandOption: true
         })
         .option('disbursement-id', {
@@ -118,10 +118,18 @@ async function main() {
         process.exit(1);
     }
 
+    // Read from an env var, not a CLI flag, so the key never lands in shell
+    // history or in `ps` output for other users on the same machine.
+    const apiKey = process.env.SDP_API_KEY;
+    if (!apiKey) {
+        logError('Missing SDP_API_KEY environment variable.');
+        process.exit(1);
+    }
+
     try {
         const { addresses, skipped, amountMismatches } = await resolveAirdropAddresses({
             sdpUrl: argv.sdpUrl,
-            apiKey: argv.sdpApiKey,
+            apiKey,
             disbursementId: argv.disbursementId,
             distributionAccount: argv.distributionAccount,
             network: argv.network,

--- a/scripts/prepare-airdrop.mjs
+++ b/scripts/prepare-airdrop.mjs
@@ -1,0 +1,150 @@
+import yargs from 'yargs';
+import fs from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { hideBin } from 'yargs/helpers';
+
+import { fetchDisbursementReceivers } from './helpers/sdp-client.mjs';
+import { computeContractAddressFromEmail, resolveNetworkPassphrase } from './helpers/contract-address.mjs';
+import { logStep, logSuccess, logWarning, logError, logInfo } from './helpers/logs.mjs';
+
+// Resolves an SDP disbursement's recipients (by email) into the contract addresses
+// generate-proofs/deploy-airdrop expect, without the manual, error-prone step of
+// cross-referencing SDP's recipient list against separately-computed addresses.
+export async function resolveAirdropAddresses({
+    sdpUrl,
+    apiKey,
+    disbursementId,
+    distributionAccount,
+    network,
+    expectedAmount
+}) {
+    const networkPassphrase = resolveNetworkPassphrase(network);
+
+    logStep('1/3', `Fetching receivers for disbursement ${disbursementId} from ${sdpUrl}`);
+    const receivers = await fetchDisbursementReceivers({ sdpUrl, apiKey, disbursementId });
+    logInfo(`Found ${receivers.length} receiver(s)`);
+
+    logStep('2/3', 'Validating receivers');
+    const seenEmails = new Set();
+    const skipped = [];
+    const amountMismatches = [];
+    const emails = [];
+
+    for (const receiver of receivers) {
+        const email = receiver.email?.trim();
+        if (!email) {
+            skipped.push({ id: receiver.id, reason: 'no email on file' });
+            continue;
+        }
+
+        const normalizedEmail = email.toLowerCase();
+        if (seenEmails.has(normalizedEmail)) {
+            skipped.push({ id: receiver.id, reason: `duplicate email ${email}` });
+            continue;
+        }
+        seenEmails.add(normalizedEmail);
+
+        const paymentAmount = receiver.payment?.amount;
+        if (expectedAmount != null && paymentAmount != null && Number(paymentAmount) !== Number(expectedAmount)) {
+            amountMismatches.push({ email, expected: expectedAmount, actual: paymentAmount });
+        }
+
+        emails.push(email);
+    }
+
+    if (skipped.length > 0) {
+        logWarning(`Skipped ${skipped.length} receiver(s):`);
+        skipped.forEach(s => logWarning(`  - ${s.id}: ${s.reason}`));
+    }
+
+    if (amountMismatches.length > 0) {
+        logWarning(`${amountMismatches.length} receiver(s) have a payment amount different from --amount (${expectedAmount}):`);
+        amountMismatches.forEach(m => logWarning(`  - ${m.email}: expected ${m.expected}, got ${m.actual}`));
+        logWarning('This script only supports a single flat amount for the whole airdrop. Double-check --amount before continuing.');
+    }
+
+    logStep('3/3', `Computing contract addresses for ${emails.length} recipient(s)`);
+    const addresses = emails.map(email =>
+        computeContractAddressFromEmail(email, distributionAccount, networkPassphrase)
+    );
+
+    return { addresses, skipped, amountMismatches };
+}
+
+async function main() {
+    const argv = await yargs(hideBin(process.argv))
+        .usage('Usage: $0 --sdp-url <url> --sdp-api-key <key> --disbursement-id <id> --distribution-account <G...> --network <testnet|mainnet> [--amount <number>] [--output <path>]')
+        .option('sdp-url', {
+            type: 'string',
+            description: 'Base URL of the SDP backend API',
+            demandOption: true
+        })
+        .option('sdp-api-key', {
+            type: 'string',
+            description: 'SDP API key with permission to read disbursement receivers',
+            demandOption: true
+        })
+        .option('disbursement-id', {
+            type: 'string',
+            description: 'SDP disbursement ID to pull receivers from',
+            demandOption: true
+        })
+        .option('distribution-account', {
+            type: 'string',
+            description: 'Public key (G...) of the SDP distribution account used as the contract deployer',
+            demandOption: true
+        })
+        .option('network', {
+            type: 'string',
+            choices: ['testnet', 'mainnet'],
+            description: 'Stellar network the contract address should be computed for',
+            demandOption: true
+        })
+        .option('amount', {
+            type: 'number',
+            description: 'Expected flat amount (in stroops) for every recipient. Used only to flag SDP payments that do not match it — this script does not support per-recipient amounts.',
+            demandOption: false
+        })
+        .option('output', {
+            type: 'string',
+            description: 'Path to write the resolved contract addresses to (one per line)',
+            default: 'recipients.txt'
+        })
+        .help()
+        .argv;
+
+    if (fs.existsSync(argv.output)) {
+        logError(`Output file already exists: ${argv.output}`);
+        process.exit(1);
+    }
+
+    try {
+        const { addresses, skipped, amountMismatches } = await resolveAirdropAddresses({
+            sdpUrl: argv.sdpUrl,
+            apiKey: argv.sdpApiKey,
+            disbursementId: argv.disbursementId,
+            distributionAccount: argv.distributionAccount,
+            network: argv.network,
+            expectedAmount: argv.amount ?? null
+        });
+
+        if (addresses.length === 0) {
+            logError('No valid recipients resolved. Nothing was written.');
+            process.exit(1);
+        }
+
+        fs.writeFileSync(argv.output, addresses.join('\n') + '\n', 'utf8');
+        logSuccess(`Wrote ${addresses.length} address(es) to ${argv.output}`);
+
+        if (skipped.length > 0 || amountMismatches.length > 0) {
+            logWarning('Review the warnings above before running generate-proofs / deploy-airdrop.');
+        }
+    } catch (error) {
+        logError(`Error: ${error.message}`);
+        process.exit(1);
+    }
+}
+
+if (process.argv[1] === fileURLToPath(import.meta.url)) {
+    main();
+}

--- a/scripts/prepare-airdrop.mjs
+++ b/scripts/prepare-airdrop.mjs
@@ -6,6 +6,7 @@ import { hideBin } from 'yargs/helpers';
 import { fetchDisbursementReceivers } from './helpers/sdp-client.mjs';
 import { computeContractAddressFromEmail, resolveNetworkPassphrase } from './helpers/contract-address.mjs';
 import { assetAmountToStroops } from './helpers/amount.mjs';
+import { maskEmail } from './helpers/mask-email.mjs';
 import { logStep, logSuccess, logWarning, logError, logInfo } from './helpers/logs.mjs';
 
 // Resolves an SDP disbursement's recipients (by email) into the contract addresses
@@ -26,6 +27,9 @@ export async function resolveAirdropAddresses({
     logInfo(`Found ${receivers.length} receiver(s)`);
 
     logStep('2/3', 'Validating receivers');
+    if (expectedAmount == null) {
+        logWarning('--amount was not provided — skipping the payment-amount sanity check entirely.');
+    }
     const seenEmails = new Set();
     const skipped = [];
     const amountMismatches = [];
@@ -40,7 +44,7 @@ export async function resolveAirdropAddresses({
 
         const normalizedEmail = email.toLowerCase();
         if (seenEmails.has(normalizedEmail)) {
-            skipped.push({ id: receiver.id, reason: `duplicate email ${email}` });
+            skipped.push({ id: receiver.id, reason: `duplicate email ${maskEmail(email)}` });
             continue;
         }
         seenEmails.add(normalizedEmail);
@@ -64,7 +68,7 @@ export async function resolveAirdropAddresses({
 
     if (amountMismatches.length > 0) {
         logWarning(`${amountMismatches.length} receiver(s) have a payment amount different from --amount (${expectedAmount}):`);
-        amountMismatches.forEach(m => logWarning(`  - ${m.email}: expected ${m.expected}, got ${m.actual}`));
+        amountMismatches.forEach(m => logWarning(`  - ${maskEmail(m.email)}: expected ${m.expected}, got ${m.actual}`));
         logWarning('This script only supports a single flat amount for the whole airdrop. Double-check --amount before continuing.');
     }
 
@@ -112,6 +116,11 @@ async function main() {
         })
         .help()
         .argv;
+
+    if (argv.amount != null && !Number.isInteger(argv.amount)) {
+        logError(`--amount must be a whole number of stroops (got ${argv.amount}).`);
+        process.exit(1);
+    }
 
     if (fs.existsSync(argv.output)) {
         logError(`Output file already exists: ${argv.output}`);

--- a/scripts/prepare-airdrop.test.mjs
+++ b/scripts/prepare-airdrop.test.mjs
@@ -1,0 +1,89 @@
+import { test } from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveAirdropAddresses } from './prepare-airdrop.mjs';
+import { computeContractAddressFromEmail, resolveNetworkPassphrase } from './helpers/contract-address.mjs';
+
+function jsonResponse(body) {
+    return new Response(JSON.stringify(body), {
+        status: 200,
+        headers: { 'Content-Type': 'application/json' }
+    });
+}
+
+const DISTRIBUTION_ACCOUNT = 'GCUZ37M45SEMGYFYYZE7IBTS3ISKGPDLFRNHS73ORSTMNYM64NLEQO76';
+
+test('skips receivers with no email and de-duplicates case-insensitively', async (t) => {
+    t.mock.method(globalThis, 'fetch', async () => jsonResponse({
+        data: [
+            { id: 'r1', email: 'alice@example.com', payment: { amount: '0.1' } },
+            { id: 'r2', email: 'Alice@Example.com', payment: { amount: '0.1' } }, // duplicate, different case
+            { id: 'r3', email: '', payment: { amount: '0.1' } }, // no email
+            { id: 'r4', email: 'bob@example.com', payment: { amount: '0.1' } }
+        ],
+        pagination: { total: 4 }
+    }));
+
+    const { addresses, skipped, amountMismatches } = await resolveAirdropAddresses({
+        sdpUrl: 'https://sdp.example.com',
+        apiKey: 'k',
+        disbursementId: 'd',
+        distributionAccount: DISTRIBUTION_ACCOUNT,
+        network: 'testnet',
+        expectedAmount: 1000000
+    });
+
+    const networkPassphrase = resolveNetworkPassphrase('testnet');
+    const expectedAddresses = ['alice@example.com', 'bob@example.com'].map(email =>
+        computeContractAddressFromEmail(email, DISTRIBUTION_ACCOUNT, networkPassphrase)
+    );
+
+    assert.deepEqual(addresses, expectedAddresses);
+    assert.equal(skipped.length, 2);
+    assert.ok(skipped.some(s => s.id === 'r3' && s.reason === 'no email on file'));
+    assert.ok(skipped.some(s => s.id === 'r2' && s.reason.includes('duplicate email')));
+    assert.equal(amountMismatches.length, 0);
+});
+
+test('flags payments whose amount does not match --amount, without dropping the recipient', async (t) => {
+    t.mock.method(globalThis, 'fetch', async () => jsonResponse({
+        data: [
+            { id: 'r1', email: 'alice@example.com', payment: { amount: '0.1' } },
+            { id: 'r2', email: 'carol@example.com', payment: { amount: '0.05' } }
+        ],
+        pagination: { total: 2 }
+    }));
+
+    const { addresses, amountMismatches } = await resolveAirdropAddresses({
+        sdpUrl: 'https://sdp.example.com',
+        apiKey: 'k',
+        disbursementId: 'd',
+        distributionAccount: DISTRIBUTION_ACCOUNT,
+        network: 'testnet',
+        expectedAmount: 1000000 // 0.1 XLM in stroops
+    });
+
+    assert.equal(addresses.length, 2); // still included, just flagged
+    assert.equal(amountMismatches.length, 1);
+    assert.equal(amountMismatches[0].email, 'carol@example.com');
+    assert.equal(amountMismatches[0].expected, 1000000);
+    assert.equal(amountMismatches[0].actual, '500000');
+});
+
+test('does not flag any mismatch when expectedAmount is not provided', async (t) => {
+    t.mock.method(globalThis, 'fetch', async () => jsonResponse({
+        data: [{ id: 'r1', email: 'alice@example.com', payment: { amount: '0.1' } }],
+        pagination: { total: 1 }
+    }));
+
+    const { amountMismatches } = await resolveAirdropAddresses({
+        sdpUrl: 'https://sdp.example.com',
+        apiKey: 'k',
+        disbursementId: 'd',
+        distributionAccount: DISTRIBUTION_ACCOUNT,
+        network: 'testnet',
+        expectedAmount: null
+    });
+
+    assert.equal(amountMismatches.length, 0);
+});


### PR DESCRIPTION
### What

Adds `scripts/prepare-airdrop.mjs`, which resolves an SDP disbursement's recipients (by email) directly into the contract addresses that `generate-proofs`/`deploy-airdrop` expect, by:
- pulling the disbursement's receivers straight from SDP's API (`GET /disbursements/{id}/receivers`, `scripts/helpers/sdp-client.mjs`)
- computing each recipient's contract address locally, via a JS port of SDP's own deterministic salt/address derivation (`scripts/helpers/contract-address.mjs`, mirrors `internal/utils/contract_salt.go` + `contract_address.go`)

`generate-proofs.mjs` and `deploy-airdrop.mjs` are unchanged — this only replaces how the input address list is produced.

### Why

Setting up an airdrop today requires manually cross-referencing SDP's disbursement recipient list (emails) against separately-computed contract addresses to build `recipients.txt` by hand — a manual step disconnected from the actual disbursement data, with no safety net if an address is wrong, missing, or mismatched against what SDP actually disbursed. This automates that step end-to-end and adds a sanity check that flags (without failing) any SDP payment amount that doesn't match the `--amount` given to the script.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [ ] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [ ] The new functionality is gated with a feature flag if this is not ready for production.
