### PR TITLE
docs: mark repo as out of scope for HackerOne program

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+> **Security Policy**: This repository is out of scope for the [Stellar HackerOne program](https://hackerone.com/stellar). It is no longer actively maintained, and does not receive security patches. Please do not submit vulnerability reports against this repo. Any vulnerability reports submitted against this repository will be closed as informational.
+
 ## Instructions
 
 ### SDP


### PR DESCRIPTION
### What

Adds a security policy notice to the top of the README marking this repository as out of scope for the [Stellar HackerOne program](https://hackerone.com/stellar).

### Why

`smart-wallet-demo-app` will no longer be actively maintained. No further security patches will be shipped. The team has been manually closing incoming HackerOne reports against this repo as informational.

### Checklist

#### PR Structure

- [x] It is not possible to break this PR down into smaller PRs.
- [x] This PR does not mix refactoring changes with feature changes.

#### Thoroughness

- [x] This PR adds tests for the new functionality or fixes.

#### Release

- [x] This is not a breaking change.
- [x] This is ready to be tested in development.
- [x] The new functionality is gated with a feature flag if this is not ready for production.
